### PR TITLE
feat: Add Citrea Testnet Support to Routing API

### DIFF
--- a/lib/config/rpcProviderProdConfig.json
+++ b/lib/config/rpcProviderProdConfig.json
@@ -53,5 +53,15 @@
     "providerUrls": ["ALCHEMY_11155111"],
     "providerNames": ["ALCHEMY"],
     "enableDbSync": false
+  },
+  {
+    "chainId": 5115,
+    "useMultiProviderProb": 1,
+    "latencyEvaluationSampleProb": 0,
+    "healthCheckSampleProb": 0,
+    "providerInitialWeights": [1],
+    "providerUrls": ["CITREA_RPC_URL"],
+    "providerNames": ["CITREA"],
+    "enableDbSync": false
   }
 ]

--- a/lib/handlers/shared.ts
+++ b/lib/handlers/shared.ts
@@ -153,6 +153,39 @@ export const DEFAULT_ROUTING_CONFIG_BY_CHAIN = (chainId: ChainId): AlphaRouterCo
         distributionPercent: 25,
         forceCrossProtocol: false,
       }
+    case ChainId.CITREA_TESTNET:
+      return {
+        // V3-only configuration for Citrea
+        v2PoolSelection: {
+          topN: 0,
+          topNDirectSwaps: 0,
+          topNTokenInOut: 0,
+          topNSecondHop: 0,
+          topNWithEachBaseToken: 0,
+          topNWithBaseToken: 0,
+        },
+        v3PoolSelection: {
+          topN: 2,
+          topNDirectSwaps: 2,
+          topNTokenInOut: 3,
+          topNSecondHop: 1,
+          topNWithEachBaseToken: 3,
+          topNWithBaseToken: 5,
+        },
+        v4PoolSelection: {
+          topN: 0,
+          topNDirectSwaps: 0,
+          topNTokenInOut: 0,
+          topNSecondHop: 0,
+          topNWithEachBaseToken: 0,
+          topNWithBaseToken: 0,
+        },
+        maxSwapsPerPath: 3,
+        minSplits: 1,
+        maxSplits: 3,
+        distributionPercent: 10,
+        forceCrossProtocol: false,
+      }
     case ChainId.ZKSYNC:
       return {
         v2PoolSelection: {

--- a/lib/rpc/utils.ts
+++ b/lib/rpc/utils.ts
@@ -14,6 +14,8 @@ export function chainIdToNetworkName(networkId: ChainId): string {
       return 'base'
     case ChainId.SEPOLIA:
       return 'sepolia'
+    case ChainId.CITREA_TESTNET:
+      return 'citrea-testnet'
     default:
       return 'ethereum'
   }
@@ -40,6 +42,9 @@ export function generateProviderUrl(key: string, value: string): string {
     }
     case 'ALCHEMY_11155111': {
       return `https://eth-sepolia-fast.g.alchemy.com/v2/${tokens[0]}`
+    }
+    case 'CITREA_RPC_URL': {
+      return tokens[0] || 'https://rpc.testnet.citrea.xyz'
     }
   }
   throw new Error(`Unknown provider-chainId pair: ${key}`)

--- a/lib/util/defaultBlocksToLiveRoutesDB.ts
+++ b/lib/util/defaultBlocksToLiveRoutesDB.ts
@@ -53,4 +53,6 @@ export const DEFAULT_BLOCKS_TO_LIVE_ROUTES_DB: { [chain in ChainId]: number } = 
   // (1 minute) / (1 seconds) = 60
   [ChainId.ZKSYNC]: 60,
   [ChainId.SONEIUM]: 60,
+  // (1 minute) / (2 seconds) = 30
+  [ChainId.CITREA_TESTNET]: 30,
 }

--- a/lib/util/newCachedRoutesRolloutPercent.ts
+++ b/lib/util/newCachedRoutesRolloutPercent.ts
@@ -35,4 +35,5 @@ export const NEW_CACHED_ROUTES_ROLLOUT_PERCENT: { [chain in ChainId]: number } =
   [ChainId.MONAD_TESTNET]: 100,
   [ChainId.BASE_SEPOLIA]: 100,
   [ChainId.SONEIUM]: 100,
+  [ChainId.CITREA_TESTNET]: 100,
 }

--- a/lib/util/tenderlyNewEndpointRolloutPercent.ts
+++ b/lib/util/tenderlyNewEndpointRolloutPercent.ts
@@ -31,4 +31,5 @@ export const TENDERLY_NEW_ENDPOINT_ROLLOUT_PERCENT: { [chain in ChainId]: number
   [ChainId.UNICHAIN]: 100,
   [ChainId.MONAD_TESTNET]: 0,
   [ChainId.SONEIUM]: 100,
+  [ChainId.CITREA_TESTNET]: 0,
 }

--- a/lib/util/testNets.ts
+++ b/lib/util/testNets.ts
@@ -13,4 +13,5 @@ export const TESTNETS = [
   ChainId.ARBITRUM_GOERLI,
   ChainId.UNICHAIN_SEPOLIA,
   ChainId.MONAD_TESTNET,
+  ChainId.CITREA_TESTNET,
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@uniswap/default-token-list": "^11.19.0",
         "@uniswap/permit2-sdk": "^1.3.0",
         "@uniswap/router-sdk": "^2.0.2",
-        "@uniswap/sdk-core": "^7.7.1",
+        "@uniswap/sdk-core": "file:../sdk/sdks/sdk-core",
         "@uniswap/smart-order-router": "4.22.19",
         "@uniswap/smart-wallet-sdk": "^2.1.1",
         "@uniswap/token-lists": "^1.0.0-beta.33",
@@ -115,6 +115,35 @@
         "tsx": "^3.12.7",
         "typechain": "^5.0.0",
         "typescript": "^4.2.3"
+      }
+    },
+    "../sdk/sdks/sdk-core": {
+      "name": "@uniswap/sdk-core",
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/address": "^5.0.2",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "big.js": "^5.2.2",
+        "decimal.js-light": "^2.5.0",
+        "jsbi": "^3.1.4",
+        "tiny-invariant": "^1.1.0",
+        "toformat": "^2.0.0"
+      },
+      "devDependencies": {
+        "@types/big.js": "^4.0.5",
+        "@types/jest": "^24.0.25",
+        "babel-eslint": "10.1.0",
+        "eslint-config-react-app": "7.0.1",
+        "eslint-plugin-flowtype": "8.0.3",
+        "eslint-plugin-jsx-a11y": "6.10.2",
+        "eslint-plugin-react": "7.37.4",
+        "eslint-plugin-react-hooks": "5.2.0",
+        "tsdx": "^0.14.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -4918,10 +4947,11 @@
         "@uniswap/v4-sdk": "^1.21.2"
       }
     },
-    "node_modules/@uniswap/sdk-core": {
+    "node_modules/@uniswap/router-sdk/node_modules/@uniswap/sdk-core": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/@uniswap/sdk-core/-/sdk-core-7.7.2.tgz",
       "integrity": "sha512-0KqXw+y0opBo6eoPAEoLHEkNpOu0NG9gEk7GAYIGok+SHX89WlykWsRYeJKTg9tOwhLpcG9oHg8xZgQ390iOrA==",
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/address": "^5.0.2",
         "@ethersproject/bytes": "^5.7.0",
@@ -4936,6 +4966,10 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@uniswap/sdk-core": {
+      "resolved": "../sdk/sdks/sdk-core",
+      "link": true
     },
     "node_modules/@uniswap/smart-order-router": {
       "version": "4.22.19",
@@ -4974,6 +5008,26 @@
       },
       "peerDependencies": {
         "jsbi": "^3.2.0"
+      }
+    },
+    "node_modules/@uniswap/smart-order-router/node_modules/@uniswap/sdk-core": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/sdk-core/-/sdk-core-7.7.2.tgz",
+      "integrity": "sha512-0KqXw+y0opBo6eoPAEoLHEkNpOu0NG9gEk7GAYIGok+SHX89WlykWsRYeJKTg9tOwhLpcG9oHg8xZgQ390iOrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/address": "^5.0.2",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "big.js": "^5.2.2",
+        "decimal.js-light": "^2.5.0",
+        "jsbi": "^3.1.4",
+        "tiny-invariant": "^1.1.0",
+        "toformat": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@uniswap/smart-order-router/node_modules/graphql": {
@@ -5038,6 +5092,26 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@uniswap/smart-wallet-sdk/node_modules/@uniswap/sdk-core": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/sdk-core/-/sdk-core-7.7.2.tgz",
+      "integrity": "sha512-0KqXw+y0opBo6eoPAEoLHEkNpOu0NG9gEk7GAYIGok+SHX89WlykWsRYeJKTg9tOwhLpcG9oHg8xZgQ390iOrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/address": "^5.0.2",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "big.js": "^5.2.2",
+        "decimal.js-light": "^2.5.0",
+        "jsbi": "^3.1.4",
+        "tiny-invariant": "^1.1.0",
+        "toformat": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@uniswap/smart-wallet-sdk/node_modules/abitype": {
@@ -5223,6 +5297,26 @@
         "node": ">=14"
       }
     },
+    "node_modules/@uniswap/universal-router-sdk/node_modules/@uniswap/sdk-core": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/sdk-core/-/sdk-core-7.7.2.tgz",
+      "integrity": "sha512-0KqXw+y0opBo6eoPAEoLHEkNpOu0NG9gEk7GAYIGok+SHX89WlykWsRYeJKTg9tOwhLpcG9oHg8xZgQ390iOrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/address": "^5.0.2",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "big.js": "^5.2.2",
+        "decimal.js-light": "^2.5.0",
+        "jsbi": "^3.1.4",
+        "tiny-invariant": "^1.1.0",
+        "toformat": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@uniswap/universal-router-sdk/node_modules/@uniswap/universal-router": {
       "version": "2.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/@uniswap/universal-router/-/universal-router-2.0.0-beta.2.tgz",
@@ -5259,6 +5353,26 @@
         "@uniswap/sdk-core": "^7.7.1",
         "tiny-invariant": "^1.1.0",
         "tiny-warning": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@uniswap/v2-sdk/node_modules/@uniswap/sdk-core": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/sdk-core/-/sdk-core-7.7.2.tgz",
+      "integrity": "sha512-0KqXw+y0opBo6eoPAEoLHEkNpOu0NG9gEk7GAYIGok+SHX89WlykWsRYeJKTg9tOwhLpcG9oHg8xZgQ390iOrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/address": "^5.0.2",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "big.js": "^5.2.2",
+        "decimal.js-light": "^2.5.0",
+        "jsbi": "^3.1.4",
+        "tiny-invariant": "^1.1.0",
+        "toformat": "^2.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -5310,6 +5424,26 @@
         "node": ">=10"
       }
     },
+    "node_modules/@uniswap/v3-sdk/node_modules/@uniswap/sdk-core": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/sdk-core/-/sdk-core-7.7.2.tgz",
+      "integrity": "sha512-0KqXw+y0opBo6eoPAEoLHEkNpOu0NG9gEk7GAYIGok+SHX89WlykWsRYeJKTg9tOwhLpcG9oHg8xZgQ390iOrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/address": "^5.0.2",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "big.js": "^5.2.2",
+        "decimal.js-light": "^2.5.0",
+        "jsbi": "^3.1.4",
+        "tiny-invariant": "^1.1.0",
+        "toformat": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@uniswap/v3-staker": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@uniswap/v3-staker/-/v3-staker-1.0.0.tgz",
@@ -5342,6 +5476,26 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@uniswap/v4-sdk/node_modules/@uniswap/sdk-core": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/@uniswap/sdk-core/-/sdk-core-7.7.2.tgz",
+      "integrity": "sha512-0KqXw+y0opBo6eoPAEoLHEkNpOu0NG9gEk7GAYIGok+SHX89WlykWsRYeJKTg9tOwhLpcG9oHg8xZgQ390iOrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/address": "^5.0.2",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "5.7.0",
+        "@ethersproject/strings": "5.7.0",
+        "big.js": "^5.2.2",
+        "decimal.js-light": "^2.5.0",
+        "jsbi": "^3.1.4",
+        "tiny-invariant": "^1.1.0",
+        "toformat": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@yarnpkg/lockfile": {
@@ -6416,6 +6570,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -7358,7 +7513,8 @@
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
-      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -25048,7 +25204,8 @@
     "node_modules/toformat": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/toformat/-/toformat-2.0.0.tgz",
-      "integrity": "sha512-03SWBVop6nU8bpyZCx7SodpYznbZF5R4ljwNLBcTQzKOD9xuihRo/psX58llS1BMFhhAI08H3luot5GoXJz2pQ=="
+      "integrity": "sha512-03SWBVop6nU8bpyZCx7SodpYznbZF5R4ljwNLBcTQzKOD9xuihRo/psX58llS1BMFhhAI08H3luot5GoXJz2pQ==",
+      "license": "MIT"
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
@@ -29568,22 +29725,47 @@
         "@uniswap/v2-sdk": "^4.15.2",
         "@uniswap/v3-sdk": "^3.25.2",
         "@uniswap/v4-sdk": "^1.21.2"
+      },
+      "dependencies": {
+        "@uniswap/sdk-core": {
+          "version": "7.7.2",
+          "resolved": "https://registry.npmjs.org/@uniswap/sdk-core/-/sdk-core-7.7.2.tgz",
+          "integrity": "sha512-0KqXw+y0opBo6eoPAEoLHEkNpOu0NG9gEk7GAYIGok+SHX89WlykWsRYeJKTg9tOwhLpcG9oHg8xZgQ390iOrA==",
+          "requires": {
+            "@ethersproject/address": "^5.0.2",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/keccak256": "5.7.0",
+            "@ethersproject/strings": "5.7.0",
+            "big.js": "^5.2.2",
+            "decimal.js-light": "^2.5.0",
+            "jsbi": "^3.1.4",
+            "tiny-invariant": "^1.1.0",
+            "toformat": "^2.0.0"
+          }
+        }
       }
     },
     "@uniswap/sdk-core": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/@uniswap/sdk-core/-/sdk-core-7.7.2.tgz",
-      "integrity": "sha512-0KqXw+y0opBo6eoPAEoLHEkNpOu0NG9gEk7GAYIGok+SHX89WlykWsRYeJKTg9tOwhLpcG9oHg8xZgQ390iOrA==",
+      "version": "file:../sdk/sdks/sdk-core",
       "requires": {
         "@ethersproject/address": "^5.0.2",
         "@ethersproject/bytes": "^5.7.0",
         "@ethersproject/keccak256": "5.7.0",
         "@ethersproject/strings": "5.7.0",
+        "@types/big.js": "^4.0.5",
+        "@types/jest": "^24.0.25",
+        "babel-eslint": "10.1.0",
         "big.js": "^5.2.2",
         "decimal.js-light": "^2.5.0",
+        "eslint-config-react-app": "7.0.1",
+        "eslint-plugin-flowtype": "8.0.3",
+        "eslint-plugin-jsx-a11y": "6.10.2",
+        "eslint-plugin-react": "7.37.4",
+        "eslint-plugin-react-hooks": "5.2.0",
         "jsbi": "^3.1.4",
         "tiny-invariant": "^1.1.0",
-        "toformat": "^2.0.0"
+        "toformat": "^2.0.0",
+        "tsdx": "^0.14.1"
       }
     },
     "@uniswap/smart-order-router": {
@@ -29619,6 +29801,22 @@
         "stats-lite": "^2.2.0"
       },
       "dependencies": {
+        "@uniswap/sdk-core": {
+          "version": "7.7.2",
+          "resolved": "https://registry.npmjs.org/@uniswap/sdk-core/-/sdk-core-7.7.2.tgz",
+          "integrity": "sha512-0KqXw+y0opBo6eoPAEoLHEkNpOu0NG9gEk7GAYIGok+SHX89WlykWsRYeJKTg9tOwhLpcG9oHg8xZgQ390iOrA==",
+          "requires": {
+            "@ethersproject/address": "^5.0.2",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/keccak256": "5.7.0",
+            "@ethersproject/strings": "5.7.0",
+            "big.js": "^5.2.2",
+            "decimal.js-light": "^2.5.0",
+            "jsbi": "^3.1.4",
+            "tiny-invariant": "^1.1.0",
+            "toformat": "^2.0.0"
+          }
+        },
         "graphql": {
           "version": "15.8.0",
           "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
@@ -29662,6 +29860,22 @@
           "requires": {
             "@noble/hashes": "~1.7.1",
             "@scure/base": "~1.2.4"
+          }
+        },
+        "@uniswap/sdk-core": {
+          "version": "7.7.2",
+          "resolved": "https://registry.npmjs.org/@uniswap/sdk-core/-/sdk-core-7.7.2.tgz",
+          "integrity": "sha512-0KqXw+y0opBo6eoPAEoLHEkNpOu0NG9gEk7GAYIGok+SHX89WlykWsRYeJKTg9tOwhLpcG9oHg8xZgQ390iOrA==",
+          "requires": {
+            "@ethersproject/address": "^5.0.2",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/keccak256": "5.7.0",
+            "@ethersproject/strings": "5.7.0",
+            "big.js": "^5.2.2",
+            "decimal.js-light": "^2.5.0",
+            "jsbi": "^3.1.4",
+            "tiny-invariant": "^1.1.0",
+            "toformat": "^2.0.0"
           }
         },
         "abitype": {
@@ -29773,6 +29987,22 @@
         "ethers": "^5.7.0"
       },
       "dependencies": {
+        "@uniswap/sdk-core": {
+          "version": "7.7.2",
+          "resolved": "https://registry.npmjs.org/@uniswap/sdk-core/-/sdk-core-7.7.2.tgz",
+          "integrity": "sha512-0KqXw+y0opBo6eoPAEoLHEkNpOu0NG9gEk7GAYIGok+SHX89WlykWsRYeJKTg9tOwhLpcG9oHg8xZgQ390iOrA==",
+          "requires": {
+            "@ethersproject/address": "^5.0.2",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/keccak256": "5.7.0",
+            "@ethersproject/strings": "5.7.0",
+            "big.js": "^5.2.2",
+            "decimal.js-light": "^2.5.0",
+            "jsbi": "^3.1.4",
+            "tiny-invariant": "^1.1.0",
+            "toformat": "^2.0.0"
+          }
+        },
         "@uniswap/universal-router": {
           "version": "2.0.0-beta.2",
           "resolved": "https://registry.npmjs.org/@uniswap/universal-router/-/universal-router-2.0.0-beta.2.tgz",
@@ -29807,6 +30037,24 @@
         "@uniswap/sdk-core": "^7.7.1",
         "tiny-invariant": "^1.1.0",
         "tiny-warning": "^1.0.3"
+      },
+      "dependencies": {
+        "@uniswap/sdk-core": {
+          "version": "7.7.2",
+          "resolved": "https://registry.npmjs.org/@uniswap/sdk-core/-/sdk-core-7.7.2.tgz",
+          "integrity": "sha512-0KqXw+y0opBo6eoPAEoLHEkNpOu0NG9gEk7GAYIGok+SHX89WlykWsRYeJKTg9tOwhLpcG9oHg8xZgQ390iOrA==",
+          "requires": {
+            "@ethersproject/address": "^5.0.2",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/keccak256": "5.7.0",
+            "@ethersproject/strings": "5.7.0",
+            "big.js": "^5.2.2",
+            "decimal.js-light": "^2.5.0",
+            "jsbi": "^3.1.4",
+            "tiny-invariant": "^1.1.0",
+            "toformat": "^2.0.0"
+          }
+        }
       }
     },
     "@uniswap/v3-core": {
@@ -29846,6 +30094,24 @@
         "@uniswap/v3-staker": "1.0.0",
         "tiny-invariant": "^1.1.0",
         "tiny-warning": "^1.0.3"
+      },
+      "dependencies": {
+        "@uniswap/sdk-core": {
+          "version": "7.7.2",
+          "resolved": "https://registry.npmjs.org/@uniswap/sdk-core/-/sdk-core-7.7.2.tgz",
+          "integrity": "sha512-0KqXw+y0opBo6eoPAEoLHEkNpOu0NG9gEk7GAYIGok+SHX89WlykWsRYeJKTg9tOwhLpcG9oHg8xZgQ390iOrA==",
+          "requires": {
+            "@ethersproject/address": "^5.0.2",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/keccak256": "5.7.0",
+            "@ethersproject/strings": "5.7.0",
+            "big.js": "^5.2.2",
+            "decimal.js-light": "^2.5.0",
+            "jsbi": "^3.1.4",
+            "tiny-invariant": "^1.1.0",
+            "toformat": "^2.0.0"
+          }
+        }
       }
     },
     "@uniswap/v3-staker": {
@@ -29875,6 +30141,24 @@
         "@uniswap/v3-sdk": "3.25.2",
         "tiny-invariant": "^1.1.0",
         "tiny-warning": "^1.0.3"
+      },
+      "dependencies": {
+        "@uniswap/sdk-core": {
+          "version": "7.7.2",
+          "resolved": "https://registry.npmjs.org/@uniswap/sdk-core/-/sdk-core-7.7.2.tgz",
+          "integrity": "sha512-0KqXw+y0opBo6eoPAEoLHEkNpOu0NG9gEk7GAYIGok+SHX89WlykWsRYeJKTg9tOwhLpcG9oHg8xZgQ390iOrA==",
+          "requires": {
+            "@ethersproject/address": "^5.0.2",
+            "@ethersproject/bytes": "^5.7.0",
+            "@ethersproject/keccak256": "5.7.0",
+            "@ethersproject/strings": "5.7.0",
+            "big.js": "^5.2.2",
+            "decimal.js-light": "^2.5.0",
+            "jsbi": "^3.1.4",
+            "tiny-invariant": "^1.1.0",
+            "toformat": "^2.0.0"
+          }
+        }
       }
     },
     "@yarnpkg/lockfile": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@uniswap/default-token-list": "^11.19.0",
     "@uniswap/permit2-sdk": "^1.3.0",
     "@uniswap/router-sdk": "^2.0.2",
-    "@uniswap/sdk-core": "^7.7.1",
+    "@uniswap/sdk-core": "file:../sdk/sdks/sdk-core",
     "@uniswap/smart-order-router": "4.22.19",
     "@uniswap/smart-wallet-sdk": "^2.1.1",
     "@uniswap/token-lists": "^1.0.0-beta.33",


### PR DESCRIPTION
## Summary
Add comprehensive support for Citrea testnet (Chain ID 5115) to the routing API, enabling V3-only routing once Uniswap V3 is deployed.

## Changes

### Configuration Updates
- **RPC Provider**: Configured Citrea testnet RPC endpoint (`https://rpc.testnet.citrea.xyz`)
- **Routing Config**: V3-only configuration with V2 and V4 pools disabled
- **Chain Utilities**: Added Citrea to all utility configurations
- **SDK Integration**: Updated to use local SDK-Core with Citrea support

### Files Modified
- `lib/config/rpcProviderProdConfig.json` - RPC provider configuration
- `lib/handlers/shared.ts` - V3-only routing configuration
- `lib/rpc/utils.ts` - Chain name mapping and RPC URL generation
- `lib/util/defaultBlocksToLiveRoutesDB.ts` - Block TTL configuration
- `lib/util/newCachedRoutesRolloutPercent.ts` - Cache rollout percentage
- `lib/util/tenderlyNewEndpointRolloutPercent.ts` - Tenderly configuration
- `lib/util/testNets.ts` - Testnet classification
- `package.json` - SDK-Core dependency update

## Testing
- [x] API builds successfully
- [ ] RPC connection verified
- [ ] Routing functionality pending V3 deployment

## Dependencies
- Requires PR JuiceSwapxyz/sdk#1 to be merged first

## Next Steps
1. Deploy Uniswap V3 contracts on Citrea testnet
2. Update contract addresses in SDK-Core
3. Test routing functionality end-to-end