### PR TITLE
fix: Add txFailureReasons field to wrap/unwrap quote response

### DIFF
--- a/src/adapters/lambdaToHttp.ts
+++ b/src/adapters/lambdaToHttp.ts
@@ -104,7 +104,8 @@ function generateWrapUnwrapResponse(body: any, isWrap: boolean): any {
       },
       gasUseEstimate: '50000',
       gasPrice: '1000000000',
-      swapper: recipient
+      swapper: recipient,
+      txFailureReasons: []
     },
     allQuotes: []
   }


### PR DESCRIPTION
- Prevents incorrect "This swap may fail" warning from appearing
- Provides empty array to indicate no known failure reasons for wrap/unwrap operations
- Improves user experience for cBTC <-> WcBTC swaps on Citrea testnet