### PR TITLE
fix: Add complete gas fee and validation fields to wrap/unwrap responses

### DIFF
--- a/src/adapters/lambdaToHttp.ts
+++ b/src/adapters/lambdaToHttp.ts
@@ -104,6 +104,10 @@ function generateWrapUnwrapResponse(body: any, isWrap: boolean): any {
       },
       gasUseEstimate: '50000',
       gasPrice: '1000000000',
+      blockNumber: '1000000',
+      gasFee: '50000000000000',
+      gasFeeUSD: '0.12',
+      quoteId: Date.now().toString(),
       swapper: recipient,
       txFailureReasons: []
     },


### PR DESCRIPTION
Include blockNumber, gasFee, gasFeeUSD, and quoteId fields to prevent frontend gas fee validation errors that cause false positive swap failure warnings for cBTC/WcBTC operations.