### PR TITLE
fix: Optimize gas limit parameters for Citrea Testnet to prevent RPC …

### DIFF
--- a/lib/util/onChainQuoteProviderConfigs.ts
+++ b/lib/util/onChainQuoteProviderConfigs.ts
@@ -129,6 +129,11 @@ export const OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [protocol in Protocol]: { 
       gasLimitPerCall: 75_000,
       quoteMinSuccessRate: 0.15,
     },
+    [ChainId.CITREA_TESTNET]: {
+      multicallChunk: 50,
+      gasLimitPerCall: 150_000,
+      quoteMinSuccessRate: 0.1,
+    },
     [ChainId.ZKSYNC]: {
       multicallChunk: 20,
       gasLimitPerCall: 4_000_000,
@@ -216,6 +221,11 @@ export const OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [protocol in Protocol]: { 
       multicallChunk: 1974,
       gasLimitPerCall: 75_000,
       quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.CITREA_TESTNET]: {
+      multicallChunk: 50,
+      gasLimitPerCall: 150_000,
+      quoteMinSuccessRate: 0.1,
     },
     [ChainId.ZKSYNC]: {
       multicallChunk: 20,
@@ -305,6 +315,11 @@ export const OPTIMISTIC_CACHED_ROUTES_BATCH_PARAMS: { [protocol in Protocol]: { 
       multicallChunk: 1974,
       gasLimitPerCall: 75_000,
       quoteMinSuccessRate: 0.15,
+    },
+    [ChainId.CITREA_TESTNET]: {
+      multicallChunk: 50,
+      gasLimitPerCall: 150_000,
+      quoteMinSuccessRate: 0.1,
     },
     [ChainId.ZKSYNC]: {
       multicallChunk: 20,


### PR DESCRIPTION
…errors

- Add Citrea-specific batch parameters with reduced multicall chunk size (50)
- Set gasLimitPerCall to 150,000 to stay within Citrea's 10M block gas limit
- Previous default config (210 chunks × 705k gas) exceeded RPC limits causing 'out of gas' errors
- Quote endpoint now successfully returns results for Citrea Testnet swaps