### PR TITLE
Disable optimistic cached routes for Citrea Testnet

### DIFF
--- a/lib/handlers/quote/quote.ts
+++ b/lib/handlers/quote/quote.ts
@@ -353,6 +353,10 @@ export class QuoteHandler extends APIGLambdaHandler<
       // override usedCachedRoutes to false. This is to ensure that we don't use
       // accidentally override usedCachedRoutes in the normal path.
       ...(enableFeeOnTransferFeeFetching ? FEE_ON_TRANSFER_SPECIFIC_CONFIG(enableFeeOnTransferFeeFetching) : {}),
+      // Citrea Testnet: Disable optimistic cached routes to avoid RPC gas limit errors
+      // The RPC node has a 10M gas limit per eth_call, and optimistic cached routes
+      // can trigger multicalls with 40+ quotes that exceed this limit
+      ...(chainId === ChainId.CITREA_TESTNET ? { optimisticCachedRoutes: false } : {}),
       ...(gasToken ? { gasToken } : {}),
       ...(excludedProtocolsFromMixed ? { excludedProtocolsFromMixed } : {}),
       shouldEnableMixedRouteEthWeth: shouldEnableMixedRouteEthWeth,


### PR DESCRIPTION
Why this works:

  1. Optimistic Cached Routes evaluate all 40+ cached routes simultaneously in ONE eth_call.
  2. This results in a multicall with >10M gas, which the Citrea RPC node rejects.
  3. With optimisticCachedRoutes: false, routes are evaluated sequentially or not used from the cache at all.
  4. This keeps multicalls below the 10M gas limit.

Trade-off:
- Quotes may be slightly slower (no optimistic cache usage).
- But: Quotes work again in the first place ✅.