### PR TITLE
Add DFX_NODE_URL environment variable for Citrea RPC configuration

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: azure/CLI@v2
         with:
           inlineScript: |
-            az containerapp update --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.AZURE_CONTAINER_APP }} --image ${{ env.DOCKER_TAGS }} --set-env-vars DEPLOY_INFO=${{ env.DEPLOY_INFO }} CITREA_RPC_URL=http://vm-dfx-node-dev.westeurope.cloudapp.azure.com:8085
+            az containerapp update --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.AZURE_CONTAINER_APP }} --image ${{ env.DOCKER_TAGS }} --set-env-vars DEPLOY_INFO=${{ env.DEPLOY_INFO }}
 
       - name: Logout from Azure
         run: az logout

--- a/.github/workflows/prd.yaml
+++ b/.github/workflows/prd.yaml
@@ -44,7 +44,7 @@ jobs:
         uses: azure/CLI@v2
         with:
           inlineScript: |
-            az containerapp update --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.AZURE_CONTAINER_APP }} --image ${{ env.DOCKER_TAGS }} --set-env-vars DEPLOY_INFO=${{ env.DEPLOY_INFO }} CITREA_RPC_URL=http://vm-dfx-node-prd.westeurope.cloudapp.azure.com:8085
+            az containerapp update --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.AZURE_CONTAINER_APP }} --image ${{ env.DOCKER_TAGS }} --set-env-vars DEPLOY_INFO=${{ env.DEPLOY_INFO }}
 
       - name: Logout from Azure
         run: az logout


### PR DESCRIPTION
- Add DFX_NODE_URL env var to support different DFX nodes per environment
- Production uses vm-dfx-node-prd:8085
- Development and local use vm-dfx-node-dev:8085
- Update GitHub Actions workflows to set correct URL per environment
- Add validation to throw error if DFX_NODE_URL is not configured