### PR TITLE
fix(v3): exclude low-liquidity Citrea pools from routing

### DIFF
--- a/src/providers/CitreaV3SubgraphProvider.ts
+++ b/src/providers/CitreaV3SubgraphProvider.ts
@@ -15,12 +15,20 @@ interface PonderPool {
   tickSpacing: number;
 }
 
+const EXCLUDED_LOW_LIQUIDITY_POOLS = [
+  "0x002afdd9272be61ce8c882839a1c88f8b75287f8",
+  "0x26bdf3981424b2097c525f2afeb4e0062a347f0d",
+  "0xd7ad0708c62327f4876c3f08ea7067e6c04da828",
+];
+
 export class CitreaV3SubgraphProvider implements IV3SubgraphProvider {
   private ponderClient: PonderClient;
   private chainId: ChainId;
+  private logger: Logger;
 
   constructor(logger: Logger, chainId: ChainId) {
     this.chainId = chainId;
+    this.logger = logger;
     this.ponderClient = getPonderClient(logger);
   }
 
@@ -36,9 +44,9 @@ export class CitreaV3SubgraphProvider implements IV3SubgraphProvider {
       direct: { items: PonderPool[] };
     }>(
       `
-            query AllPoolsWithTokens($tokenIn: String = "", $tokenOut: String = "", $chainId: Int = 0) {
+            query AllPoolsWithTokens($tokenIn: String = "", $tokenOut: String = "", $chainId: Int = 0, $excludedPools: [String!] = []) {
                 allPools:pools(
-                    where: {OR: {token0: $tokenIn, token1: $tokenIn, OR: {token0: $tokenOut, token1: $tokenOut}}, AND: {chainId: $chainId}}
+                    where: {OR: {token0: $tokenIn, token1: $tokenIn, OR: {token0: $tokenOut, token1: $tokenOut}}, AND: {chainId: $chainId, address_not_in: $excludedPools}}
                     limit: 1000
                 ) {
                     items {
@@ -55,6 +63,7 @@ export class CitreaV3SubgraphProvider implements IV3SubgraphProvider {
                       {AND: {token0: $tokenIn, token1: $tokenOut, chainId: $chainId}}
                       {AND: {token1: $tokenIn, token0: $tokenOut, chainId: $chainId}}
                     ]
+                    AND: {address_not_in: $excludedPools}
                   }) {
                   items{
                     address
@@ -70,11 +79,19 @@ export class CitreaV3SubgraphProvider implements IV3SubgraphProvider {
         tokenIn: tokenInAddress,
         tokenOut: tokenOutAddress,
         chainId: this.chainId,
+        excludedPools: EXCLUDED_LOW_LIQUIDITY_POOLS,
       },
     );
 
-    const directPools = ponderPools.direct.items;
-    const allPools = ponderPools.allPools.items;
+    // Keep a defensive filter here in case query-side filtering changes upstream.
+    const directPools = ponderPools.direct.items.filter(
+      (pool) =>
+        !EXCLUDED_LOW_LIQUIDITY_POOLS.includes(pool.address.toLowerCase()),
+    );
+    const allPools = ponderPools.allPools.items.filter(
+      (pool) =>
+        !EXCLUDED_LOW_LIQUIDITY_POOLS.includes(pool.address.toLowerCase()),
+    );
     const resultPools = directPools.length > 0 ? directPools : allPools;
 
     const pools: V3SubgraphPool[] = resultPools.map((pool) => {
@@ -88,6 +105,25 @@ export class CitreaV3SubgraphProvider implements IV3SubgraphProvider {
         tvlUSD: 1000,
       };
     });
+
+    this.logger.info(
+      {
+        provider: "CitreaV3SubgraphProvider",
+        chainId: this.chainId,
+        tokenIn: tokenInAddress,
+        tokenOut: tokenOutAddress,
+        directPoolCount: directPools.length,
+        candidatePoolCount: allPools.length,
+        selectedPoolCount: pools.length,
+        selectedPools: pools.map((pool) => ({
+          id: pool.id,
+          token0: pool.token0.id,
+          token1: pool.token1.id,
+          feeTier: pool.feeTier,
+        })),
+      },
+      "V3 pools selected for routing",
+    );
 
     return pools;
   }

--- a/src/providers/CitreaV3SubgraphProvider.ts
+++ b/src/providers/CitreaV3SubgraphProvider.ts
@@ -24,11 +24,9 @@ const EXCLUDED_LOW_LIQUIDITY_POOLS = [
 export class CitreaV3SubgraphProvider implements IV3SubgraphProvider {
   private ponderClient: PonderClient;
   private chainId: ChainId;
-  private logger: Logger;
 
   constructor(logger: Logger, chainId: ChainId) {
     this.chainId = chainId;
-    this.logger = logger;
     this.ponderClient = getPonderClient(logger);
   }
 
@@ -105,25 +103,6 @@ export class CitreaV3SubgraphProvider implements IV3SubgraphProvider {
         tvlUSD: 1000,
       };
     });
-
-    this.logger.info(
-      {
-        provider: "CitreaV3SubgraphProvider",
-        chainId: this.chainId,
-        tokenIn: tokenInAddress,
-        tokenOut: tokenOutAddress,
-        directPoolCount: directPools.length,
-        candidatePoolCount: allPools.length,
-        selectedPoolCount: pools.length,
-        selectedPools: pools.map((pool) => ({
-          id: pool.id,
-          token0: pool.token0.id,
-          token1: pool.token1.id,
-          feeTier: pool.feeTier,
-        })),
-      },
-      "V3 pools selected for routing",
-    );
 
     return pools;
   }


### PR DESCRIPTION
## Summary
- Exclude three known low-liquidity Citrea V3 pools from `CitreaV3SubgraphProvider` query results.
- Add query-side filtering via `address_not_in` and keep a defensive in-code filter as a fallback.
- Keep existing pool-selection logging so routing inputs remain visible in logs.

## Test plan
- [x] Run the quote request that previously failed on `ProviderGasError`.
- [x] Verify `V3 pools selected for routing` no longer includes the excluded pool addresses.
- [x] Confirm router still computes V3 candidate routes with remaining pools.