### PR TITLE
fix(router): disable split routes

### DIFF
--- a/src/core/RouterService.ts
+++ b/src/core/RouterService.ts
@@ -411,8 +411,8 @@ export class RouterService {
       },
       maxSwapsPerPath: 3,
       minSplits: 1,
-      maxSplits: 3,
-      distributionPercent: 10,
+      maxSplits: 1,
+      distributionPercent: 100,
       forceCrossProtocol: false,
       optimisticCachedRoutes: false,
     };


### PR DESCRIPTION
## Summary
- Set `maxSplits` to `1` to disable split routes
- Set `distributionPercent` to `100` accordingly