### PR TITLE
fix: downgrade launchpad 404 logs from error to debug

### DIFF
--- a/src/endpoints/launchpad.ts
+++ b/src/endpoints/launchpad.ts
@@ -162,8 +162,12 @@ export function createLaunchpadTokenHandler(logger: Logger) {
 
       res.status(200).json(response.data);
     } catch (error: any) {
-      log.error({ error: error.message }, "Error fetching launchpad token");
       const status = error.response?.status || 500;
+      if (status === 404) {
+        log.debug({ address: req.params.address }, "Launchpad token not found");
+      } else {
+        log.error({ error: error.message }, "Error fetching launchpad token");
+      }
       res.status(status).json({
         error: error.response?.data?.error || "Failed to fetch launchpad token",
       });

--- a/src/services/PonderClient.ts
+++ b/src/services/PonderClient.ts
@@ -121,7 +121,15 @@ export class PonderClient {
       activateFallback(this.logger);
       shouldRetry = true;
     }
-    // Other errors (400, 404, 500, etc.) - don't retry, just throw
+    // 404 - resource not found, expected for non-launchpad tokens
+    else if (status === 404) {
+      this.logger.debug(
+        `[Ponder] ${method} resource not found (404), not retrying`,
+        { status, path },
+      );
+      return { shouldRetry: false, shouldThrow: true };
+    }
+    // Other errors (400, 500, etc.) - don't retry, just throw
     else {
       this.logger.error(
         `[Ponder] ${method} non-network error from primary, not retrying`,


### PR DESCRIPTION
## Summary
- PonderClient: dedicated 404 handler with `debug` log level instead of `error`
- Launchpad API endpoint: log 404 as `debug`, keep `error` for real failures
- Non-launchpad tokens (WBTC, cUSD, USDC etc.) queried via `/launchpad/token/:address` correctly return 404 — this is expected behavior, not an error

## Context
The frontend's `QueryTokenLogo` and `CurrencyLogoOverrideContext` call the launchpad token endpoint for every displayed token to check for custom logos. For non-launchpad tokens this returns 404, which was logged at error level causing ~10 errors/min noise in Grafana.

## Test plan
- [ ] Verify 404 responses still work correctly for non-launchpad tokens
- [ ] Verify actual errors (500, network) are still logged at error level
- [ ] Check Grafana log volume drops after deploy