### PR TITLE
Fix CoinGecko 429 retry storms by refreshing stale cache timestamps

### DIFF
--- a/src/services/PriceService.ts
+++ b/src/services/PriceService.ts
@@ -50,6 +50,7 @@ export class PriceService {
   private btcPriceHistoryInflight: Promise<BtcPriceHistory | null> | null =
     null;
   private readonly CACHE_TTL = 60_000; // 60 seconds
+  private readonly coinGeckoHeaders: Record<string, string>;
 
   // Known BTC-pegged tokens by chain (lowercased addresses)
   private btcTokens: Map<number, Set<string>> = new Map();
@@ -59,6 +60,11 @@ export class PriceService {
 
   constructor(logger: Logger) {
     this.logger = logger.child({ service: "PriceService" });
+    this.coinGeckoHeaders = { accept: "application/json" };
+    const apiKey = process.env.COINGECKO_API_KEY;
+    if (apiKey) {
+      this.coinGeckoHeaders["x-cg-demo-api-key"] = apiKey;
+    }
     this.initializeKnownTokens();
   }
 
@@ -184,6 +190,7 @@ export class PriceService {
         "https://api.coingecko.com/api/v3/coins/bitcoin/market_chart",
         {
           params: { vs_currency: "usd", days: 1 },
+          headers: this.coinGeckoHeaders,
           timeout: 5000,
         },
       );
@@ -273,6 +280,7 @@ export class PriceService {
           developer_data: false,
           sparkline: false,
         },
+        headers: this.coinGeckoHeaders,
         timeout: 5000,
       },
     );
@@ -391,6 +399,7 @@ export class PriceService {
       "https://api.coingecko.com/api/v3/simple/price",
       {
         params: { ids: "bitcoin", vs_currencies: "usd" },
+        headers: this.coinGeckoHeaders,
         timeout: 5000,
       },
     );

--- a/src/services/PriceService.ts
+++ b/src/services/PriceService.ts
@@ -219,6 +219,8 @@ export class PriceService {
         "Failed to fetch BTC price history from CoinGecko",
       );
       if (this.btcPriceHistoryCache) {
+        // Refresh timestamp so we don't retry on every call while rate-limited
+        this.btcPriceHistoryCache.timestamp = Date.now();
         return this.btcPriceHistoryCache.data;
       }
       return null;
@@ -250,6 +252,8 @@ export class PriceService {
           "Both BTC price data sources failed",
         );
         if (this.btcPriceDataCache) {
+          // Refresh timestamp so we don't retry on every call while rate-limited
+          this.btcPriceDataCache.timestamp = Date.now();
           return this.btcPriceDataCache.data;
         }
         throw new Error("Unable to fetch BTC price data");
@@ -312,6 +316,8 @@ export class PriceService {
         );
         // Return stale cache if available
         if (this.btcPriceCache) {
+          // Refresh timestamp so we don't retry on every call while rate-limited
+          this.btcPriceCache.timestamp = Date.now();
           return this.btcPriceCache.price;
         }
         throw new Error("Unable to fetch BTC price");


### PR DESCRIPTION
## Summary
- **Cache stampede fix**: When CoinGecko returns HTTP 429, stale cached values were returned but the cache timestamp was not refreshed — causing every call after the 60s TTL to retry and fail again. Now stale values get a fresh timestamp.
- **API key support**: Read `COINGECKO_API_KEY` from environment and send it as `x-cg-demo-api-key` header on all three CoinGecko endpoints. This raises the rate limit from ~10 to 30 calls/min.

## Test plan
- [ ] Verify CoinGecko 429 errors stop after deploy (with API key configured)
- [ ] Confirm BTC prices, price changes, and price history still update correctly