### PR TITLE
Add /dependenciesz endpoint for LDS health monitoring

### DIFF
--- a/src/middleware/rateLimiter.ts
+++ b/src/middleware/rateLimiter.ts
@@ -68,7 +68,7 @@ export const quoteLimiter = isDevelopment
 
       // Skip rate limiting for health checks
       skip: (req) => {
-        return req.path === "/healthz" || req.path === "/readyz";
+        return req.path === "/healthz" || req.path === "/readyz" || req.path === "/dependenciesz";
       },
     });
 
@@ -107,6 +107,6 @@ export const generalLimiter = isDevelopment
 
       // Skip rate limiting for health checks
       skip: (req) => {
-        return req.path === "/healthz" || req.path === "/readyz";
+        return req.path === "/healthz" || req.path === "/readyz" || req.path === "/dependenciesz";
       },
     });

--- a/src/server.ts
+++ b/src/server.ts
@@ -87,6 +87,7 @@ import {
   PoolTransactionsQuerySchema,
   PoolTicksQuerySchema,
 } from "./validation/schemas";
+import axios from "axios";
 import packageJson from "../package.json";
 import { createSwapApproveHandler } from "./endpoints/swapApprove";
 import { createLightningInvoiceHandler } from "./endpoints/lightningInvoice";
@@ -700,6 +701,49 @@ async function bootstrap() {
     } else {
       res.status(503).send("not ready");
     }
+  });
+
+  // Dependency health check endpoint
+  app.get("/dependenciesz", async (_req: Request, res: Response) => {
+    const ldsBaseUrl = process.env.LDS_API_URL || "https://lightning.space/v1";
+    const timeout = 5000;
+
+    const checks = [
+      { name: "lds-api", url: `${ldsBaseUrl}/boltz/balance` },
+      { name: "lds-boltz", url: `${ldsBaseUrl}/swap/version` },
+      { name: "lds-claim", url: `${ldsBaseUrl}/claim/graphql` },
+      { name: "lds-bitcoin-node", url: `${ldsBaseUrl}/swap/v2/chain/BTC/height` },
+      { name: "lds-citrea-node", url: `${ldsBaseUrl}/swap/v2/chain/cBTC/height` },
+      { name: "lds-ethereum-node", url: `${ldsBaseUrl}/swap/v2/chain/USDT_ETH/height` },
+      { name: "lds-lnd", url: `${ldsBaseUrl}/lndhub/getinfo` },
+    ];
+
+    const results = await Promise.all(
+      checks.map(async (check) => {
+        const start = Date.now();
+        try {
+          const response = await axios.get(check.url, { timeout });
+          return {
+            name: check.name,
+            status: response.status >= 200 && response.status < 400 ? "up" : "down",
+            responseTime: Date.now() - start,
+          };
+        } catch {
+          return {
+            name: check.name,
+            status: "down",
+            responseTime: Date.now() - start,
+          };
+        }
+      }),
+    );
+
+    const allUp = results.every((r) => r.status === "up");
+
+    res.status(allUp ? 200 : 503).json({
+      status: allUp ? "healthy" : "degraded",
+      dependencies: results,
+    });
   });
 
   // Version endpoint


### PR DESCRIPTION
## Summary
- Adds `/dependenciesz` endpoint that probes 7 critical Lightning.space services (API, Boltz, Claim, BTC/Citrea/ETH nodes, LND)
- Returns `200 healthy` if all dependencies are up, `503 degraded` if any are down
- Each check includes name, status, and response time
- Endpoint is excluded from rate limiting

## Context
The JuiceSwap status page (status.juiceswap.com) only monitors own services but not upstream LDS dependencies. This endpoint enables a single Uptime Kuma monitor to detect when LDS services are degraded, so the status page reflects the actual user experience.

## Test plan
- [ ] Deploy to dev and verify `GET /dependenciesz` returns expected JSON
- [ ] Confirm `503` response when an LDS service is down
- [ ] Add Uptime Kuma monitor for `https://api.juiceswap.com/dependenciesz`
- [ ] Add monitor to JuiceSwap status page