### PR TITLE
chore: reduce noisy warn logs for Ponder, gateway fee, and gas estimate

### DIFF
--- a/src/endpoints/swap.ts
+++ b/src/endpoints/swap.ts
@@ -552,7 +552,7 @@ async function handleGatewaySwap(
         });
         gasLimit = estimatedGas.mul(110).div(100); // 10% buffer
       } catch (e) {
-        log.warn(
+        log.info(
           { error: e },
           "Gas estimation failed for direct conversion, using default",
         );
@@ -667,7 +667,7 @@ async function handleGatewaySwap(
       });
       gasLimit = estimatedGas.mul(110).div(100); // 10% buffer
     } catch (e) {
-      log.warn(
+      log.info(
         { error: e },
         "Gas estimation failed for Gateway swap, using default",
       );
@@ -885,7 +885,7 @@ async function handleClassicSwap(
       });
       gasLimit = estimatedGas.mul(110).div(100); // 10% buffer
     } catch (e) {
-      log.warn(
+      log.info(
         { error: e },
         "Gas estimation failed for Classic swap, using default",
       );

--- a/src/services/JuiceGatewayService.ts
+++ b/src/services/JuiceGatewayService.ts
@@ -223,7 +223,7 @@ export class JuiceGatewayService {
       const fee = await contract.DEFAULT_FEE();
       return (fee as ethers.BigNumber).toNumber();
     } catch (error) {
-      this.logger.warn(
+      this.logger.info(
         { chainId, error },
         "Failed to get default fee, using 3000",
       );

--- a/src/services/PonderClient.ts
+++ b/src/services/PonderClient.ts
@@ -80,26 +80,45 @@ export class PonderClient {
       url ===
       (process.env.PONDER_FALLBACK_URL || "https://dev.ponder.juiceswap.com");
 
-    this.logger.warn(
-      {
-        method,
-        path,
-        attempt,
-        maxRetries,
-        error: error.message,
-        status,
-        isAxiosError,
-        wasUsingFallback,
-      },
-      `Ponder ${method} request failed`,
-    );
+    const failureCtx = {
+      method,
+      path,
+      attempt,
+      maxRetries,
+      error: error.message,
+      status,
+      isAxiosError,
+      wasUsingFallback,
+    };
+
+    // 404 on primary — expected for missing resources; avoid info/warn noise in prod
+    if (!wasUsingFallback && status === 404) {
+      this.logger.debug(
+        failureCtx,
+        `Ponder ${method} resource not found (404), not retrying`,
+      );
+      return { shouldRetry: false, shouldThrow: true };
+    }
 
     // If fallback failed, give up immediately
     // No retries on fallback errors - just return the error to the caller
     if (wasUsingFallback) {
+      if (status === 404) {
+        this.logger.debug(
+          failureCtx,
+          `Ponder ${method} request failed (404 on fallback)`,
+        );
+      } else {
+        this.logger.info(
+          failureCtx,
+          `Ponder ${method} request failed`,
+        );
+      }
       this.logger.error(`[Ponder] ${method} fallback server failed, giving up`);
       return { shouldRetry: false, shouldThrow: true };
     }
+
+    this.logger.info(failureCtx, `Ponder ${method} request failed`);
 
     // We're on primary - only handle network errors
     // Network errors include: 503 and connection/timeout errors
@@ -120,14 +139,6 @@ export class PonderClient {
       );
       activateFallback(this.logger);
       shouldRetry = true;
-    }
-    // 404 - resource not found, expected for non-launchpad tokens
-    else if (status === 404) {
-      this.logger.debug(
-        `[Ponder] ${method} resource not found (404), not retrying`,
-        { status, path },
-      );
-      return { shouldRetry: false, shouldThrow: true };
     }
     // Other errors (400, 500, etc.) - don't retry, just throw
     else {

--- a/src/services/PonderClient.ts
+++ b/src/services/PonderClient.ts
@@ -109,10 +109,7 @@ export class PonderClient {
           `Ponder ${method} request failed (404 on fallback)`,
         );
       } else {
-        this.logger.info(
-          failureCtx,
-          `Ponder ${method} request failed`,
-        );
+        this.logger.info(failureCtx, `Ponder ${method} request failed`);
       }
       this.logger.error(`[Ponder] ${method} fallback server failed, giving up`);
       return { shouldRetry: false, shouldThrow: true };


### PR DESCRIPTION
Adjusts log levels so routine fallbacks and expected Ponder 404s do not show as warnings in production.

### PonderClient
- Primary HTTP 404: single structured `debug` entry (no info/warn).
- Fallback 404: `debug` before the existing error when giving up.
- Fallback non-404: `info` before error.
- Other primary failures: `info` before existing 503/network warn and error paths.

### JuiceGatewayService
- `getDefaultFee` catch: `warn` → `info` when defaulting to 3000.

### swap
- Gas estimation catch blocks (direct conversion, Gateway swap, Classic swap): `warn` → `info` when using default gas limit.