### PR TITLE
fix: avoid Grafana ERROR misclassification from error field in info logs

### DIFF
--- a/src/endpoints/swap.ts
+++ b/src/endpoints/swap.ts
@@ -551,9 +551,14 @@ async function handleGatewaySwap(
           value: "0x0",
         });
         gasLimit = estimatedGas.mul(110).div(100); // 10% buffer
-      } catch (e) {
+      } catch (e: unknown) {
+        const err = e as { message?: string; code?: string; reason?: string };
         log.info(
-          { error: e },
+          {
+            errMessage: err?.message,
+            errCode: err?.code,
+            errReason: err?.reason,
+          },
           "Gas estimation failed for direct conversion, using default",
         );
       }
@@ -666,9 +671,14 @@ async function handleGatewaySwap(
         value: isNativeInput ? body.amount : "0x0",
       });
       gasLimit = estimatedGas.mul(110).div(100); // 10% buffer
-    } catch (e) {
+    } catch (e: unknown) {
+      const err = e as { message?: string; code?: string; reason?: string };
       log.info(
-        { error: e },
+        {
+          errMessage: err?.message,
+          errCode: err?.code,
+          errReason: err?.reason,
+        },
         "Gas estimation failed for Gateway swap, using default",
       );
     }
@@ -884,9 +894,14 @@ async function handleClassicSwap(
         value: swapRoute.methodParameters.value,
       });
       gasLimit = estimatedGas.mul(110).div(100); // 10% buffer
-    } catch (e) {
+    } catch (e: unknown) {
+      const err = e as { message?: string; code?: string; reason?: string };
       log.info(
-        { error: e },
+        {
+          errMessage: err?.message,
+          errCode: err?.code,
+          errReason: err?.reason,
+        },
         "Gas estimation failed for Classic swap, using default",
       );
     }

--- a/src/services/JuiceGatewayService.ts
+++ b/src/services/JuiceGatewayService.ts
@@ -222,9 +222,22 @@ export class JuiceGatewayService {
     try {
       const fee = await contract.DEFAULT_FEE();
       return (fee as ethers.BigNumber).toNumber();
-    } catch (error) {
+    } catch (error: unknown) {
+      const e = error as {
+        message?: string;
+        code?: string;
+        reason?: string;
+        error?: { message?: string; code?: number };
+      };
       this.logger.info(
-        { chainId, error },
+        {
+          chainId,
+          errMessage: e?.message,
+          errCode: e?.code,
+          errReason: e?.reason,
+          rpcMessage: e?.error?.message,
+          rpcCode: e?.error?.code,
+        },
         "Failed to get default fee, using 3000",
       );
       return 3000;


### PR DESCRIPTION
Grafana log viewer promotes entries to ERROR when the JSON payload contains a field named `error`, regardless of the Bunyan `level` value. All affected catch blocks were logging `{ error: e }` which serialised to `"error":{}` (non-enumerable Error properties), triggering the false positive.

### Changes
- `JuiceGatewayService.getDefaultFee`: replace `{ error }` with `{ errMessage, errCode, errReason, rpcMessage, rpcCode }`.
- `swap.ts` (3 gas-estimation catches — direct conversion, Gateway swap, Classic swap): same rename.