### PR TITLE
Fix: Remove unnecessary RPC calls for non-Citrea chains

### DIFF
--- a/src/core/RouterService.ts
+++ b/src/core/RouterService.ts
@@ -104,12 +104,21 @@ export class RouterService {
     return instance;
   }
 
+  // Chains that need AlphaRouter (DEX routing). Other chains only need RPC providers (bridge, gas).
+  private static readonly ROUTING_CHAINS = new Set<ChainId>([
+    ChainId.CITREA_MAINNET,
+    ChainId.CITREA_TESTNET,
+  ]);
+
   private async initialize(): Promise<void> {
     // Enable smart-order-router internal logging
     setGlobalLogger(this.logger);
 
-    // Initialize routers for each chain with essential providers
+    // Initialize routers only for chains that need DEX routing
     for (const [chainId, provider] of this.providers.entries()) {
+      if (!RouterService.ROUTING_CHAINS.has(chainId)) {
+        continue;
+      }
       // Initialize multicall provider for efficient batching
       const multicallProvider = new UniswapMulticallProvider(
         chainId,

--- a/src/services/PriceService.ts
+++ b/src/services/PriceService.ts
@@ -49,7 +49,7 @@ export class PriceService {
   private btcPriceHistoryCache: BtcPriceHistoryCache | null = null;
   private btcPriceHistoryInflight: Promise<BtcPriceHistory | null> | null =
     null;
-  private readonly CACHE_TTL = 60_000; // 60 seconds
+  private readonly CACHE_TTL = 300_000; // 5 minutes
   private readonly coinGeckoHeaders: Record<string, string>;
 
   // Known BTC-pegged tokens by chain (lowercased addresses)

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -33,6 +33,15 @@ export const ChainIdSchema = z
     (val) => [1, 11155111, 137, 5115, 4114].includes(val),
     "Unsupported chain ID",
   );
+
+// Chains with DEX routing support (AlphaRouter). Used for quote/swap endpoints.
+export const RoutingChainIdSchema = z
+  .number()
+  .int()
+  .refine(
+    (val) => [5115, 4114].includes(val),
+    "Unsupported chain ID for routing",
+  );
 export const AmountSchema = z
   .string()
   .regex(/^[1-9]\d*$/, "Amount must be a positive non-zero integer string");
@@ -61,11 +70,11 @@ export const SlippageToleranceSchema = z.coerce
 // Quote endpoint schema
 export const QuoteRequestSchema = z
   .object({
-    tokenInChainId: ChainIdSchema,
+    tokenInChainId: RoutingChainIdSchema,
     tokenIn: AddressSchema.optional(),
     tokenInAddress: AddressSchema.optional(),
     tokenInDecimals: z.coerce.number().int().positive().optional(),
-    tokenOutChainId: ChainIdSchema,
+    tokenOutChainId: RoutingChainIdSchema,
     tokenOut: AddressSchema.optional(),
     tokenOutAddress: AddressSchema.optional(),
     tokenOutDecimals: z.coerce.number().int().positive().optional(),
@@ -102,11 +111,11 @@ const RequiredSlippageToleranceSchema = z.coerce.string().refine(
 export const SwapRequestSchema = z
   .object({
     type: z.enum(["WRAP", "UNWRAP", "exactIn", "exactOut"]).optional(),
-    tokenInChainId: ChainIdSchema,
+    tokenInChainId: RoutingChainIdSchema,
     tokenIn: AddressSchema.optional(),
     tokenInAddress: AddressSchema.optional(),
     tokenInDecimals: z.coerce.number().int().positive().optional(),
-    tokenOutChainId: ChainIdSchema,
+    tokenOutChainId: RoutingChainIdSchema,
     tokenOut: AddressSchema.optional(),
     tokenOutAddress: AddressSchema.optional(),
     tokenOutDecimals: z.coerce.number().int().positive().optional(),
@@ -115,7 +124,7 @@ export const SwapRequestSchema = z
     slippageTolerance: RequiredSlippageToleranceSchema,
     deadline: z.coerce.string().optional(),
     from: AddressSchema,
-    chainId: ChainIdSchema.optional(),
+    chainId: RoutingChainIdSchema.optional(),
     enableUniversalRouter: z.boolean().optional(),
     simulate: z.boolean().optional(),
     protocols: z.array(z.string()).optional(),
@@ -137,7 +146,7 @@ export const SwappableTokensQuerySchema = z.object({
   tokenInChainId: z
     .string()
     .transform((val) => parseInt(val, 10))
-    .pipe(ChainIdSchema),
+    .pipe(RoutingChainIdSchema),
   tokenIn: AddressSchema.optional(),
 });
 


### PR DESCRIPTION
## Summary
- Skip AlphaRouter + TokenProvider initialization for ETH/Polygon/Sepolia — only Citrea chains (4114/5115) need DEX routing
- Add `RoutingChainIdSchema` to reject quote/swap requests for non-Citrea chains at validation level
- Increase PriceService CoinGecko cache TTL from 60s to 5 minutes to reduce rate limit pressure
- RPC providers for all chains remain intact for bridge swap operations

## Context
Grafana logs showed persistent errors:
- **dfxprd**: "Failed to lookup token using token provider" for USDC/USDT on ETH (chainId 1) and Polygon (chainId 137)
- **dfxdev**: CoinGecko 429 (Too Many Requests) on `/coins/bitcoin` and `/market_chart`

Root cause: AlphaRouter was initialized for all 5 chains at startup, creating TokenProviders that make unnecessary Alchemy on-chain calls for chains where no DEX routing happens.

## Test plan
- [ ] Verify API starts without errors (no router init for ETH/Polygon/Sepolia)
- [ ] Verify quote/swap requests with Citrea chainIds still work
- [ ] Verify quote/swap requests with chainId 1/137 return validation error
- [ ] Verify bridge swap endpoints still work (use ChainIdSchema, not RoutingChainIdSchema)
- [ ] Monitor Grafana for reduction in "Failed to lookup token" errors
- [ ] Monitor CoinGecko 429 errors (should decrease with 5min TTL)