### PR TITLE
fix: downgrade gas estimation fallback logs to debug

### DIFF
--- a/src/endpoints/quote.ts
+++ b/src/endpoints/quote.ts
@@ -621,9 +621,9 @@ export function createQuoteHandler(
             // Bridge liquidity error - fall through to classic V3 routing
             // This allows direct pools (e.g., ctUSD/USDC.e) to be used when bridge is empty
             if (error instanceof BridgeLiquidityError) {
-              log.info(
+              log.debug(
                 {
-                  error: error.message,
+                  reason: error.message,
                   available: error.available,
                   required: error.required,
                   tokenIn,

--- a/src/endpoints/swap.ts
+++ b/src/endpoints/swap.ts
@@ -553,11 +553,11 @@ async function handleGatewaySwap(
         gasLimit = estimatedGas.mul(110).div(100); // 10% buffer
       } catch (e: unknown) {
         const err = e as { message?: string; code?: string; reason?: string };
-        log.info(
+        log.debug(
           {
-            errMessage: err?.message,
-            errCode: err?.code,
-            errReason: err?.reason,
+            fallbackMessage: err?.message,
+            fallbackCode: err?.code,
+            fallbackReason: err?.reason,
           },
           "Gas estimation failed for direct conversion, using default",
         );
@@ -673,11 +673,11 @@ async function handleGatewaySwap(
       gasLimit = estimatedGas.mul(110).div(100); // 10% buffer
     } catch (e: unknown) {
       const err = e as { message?: string; code?: string; reason?: string };
-      log.info(
+      log.debug(
         {
-          errMessage: err?.message,
-          errCode: err?.code,
-          errReason: err?.reason,
+          fallbackMessage: err?.message,
+          fallbackCode: err?.code,
+          fallbackReason: err?.reason,
         },
         "Gas estimation failed for Gateway swap, using default",
       );
@@ -730,9 +730,9 @@ async function handleGatewaySwap(
     // Bridge liquidity error - fall through to classic V3 routing
     // This allows direct pools (e.g., ctUSD/USDC.e) to be used when bridge is empty
     if (error instanceof BridgeLiquidityError) {
-      log.info(
+      log.debug(
         {
-          error: error.message,
+          reason: error.message,
           available: error.available,
           required: error.required,
         },
@@ -896,11 +896,11 @@ async function handleClassicSwap(
       gasLimit = estimatedGas.mul(110).div(100); // 10% buffer
     } catch (e: unknown) {
       const err = e as { message?: string; code?: string; reason?: string };
-      log.info(
+      log.debug(
         {
-          errMessage: err?.message,
-          errCode: err?.code,
-          errReason: err?.reason,
+          fallbackMessage: err?.message,
+          fallbackCode: err?.code,
+          fallbackReason: err?.reason,
         },
         "Gas estimation failed for Classic swap, using default",
       );


### PR DESCRIPTION
## Summary
- Gas estimation fallback logs (`log.info` → `log.debug`) downgraded to prevent Loki `detected_level=error` misclassification
- Renamed `errMessage`/`errCode`/`errReason` fields to `fallbackMessage`/`fallbackCode`/`fallbackReason`
- Renamed `error:` field to `reason:` in bridge liquidity fallback logs
- Affects `swap.ts` (4 locations) and `quote.ts` (1 location)

## Context
~400 false error logs/hour in Grafana caused by:
- 48% from wallets without gas (insufficient funds for simulation)
- 43% from `UNCONNECTED_ADDRESS` (0xAAAA...) dummy wallet with no funds
- All cases fall back correctly to default gas limits — expected behavior, not actual errors

## Test plan
- [ ] Verify swap endpoint still returns correct gas estimates
- [ ] Confirm Grafana error count drops after deploy
- [ ] Check that debug logs still appear when log level is set to debug