### PR TITLE
fix: downgrade gateway default fee fallback log to debug

### DIFF
--- a/src/services/JuiceGatewayService.ts
+++ b/src/services/JuiceGatewayService.ts
@@ -229,12 +229,12 @@ export class JuiceGatewayService {
         reason?: string;
         error?: { message?: string; code?: number };
       };
-      this.logger.info(
+      this.logger.debug(
         {
           chainId,
-          errMessage: e?.message,
-          errCode: e?.code,
-          errReason: e?.reason,
+          fallbackMessage: e?.message,
+          fallbackCode: e?.code,
+          fallbackReason: e?.reason,
           rpcMessage: e?.error?.message,
           rpcCode: e?.error?.code,
         },


### PR DESCRIPTION
## Summary
- Same pattern as #244 — `log.info` → `log.debug`, `errMessage`/`errCode`/`errReason` → `fallbackMessage`/`fallbackCode`/`fallbackReason`
- Affects `JuiceGatewayService.ts` (1 location: "Failed to get default fee, using 3000")

## Test plan
- [ ] Verify gateway swaps still work correctly
- [ ] Confirm no new error misclassification in Grafana