### PR TITLE
fix: add errorFields helper and cold-start backoff for CoinGecko rate limits

### DIFF
--- a/src/services/ExploreStatsService.ts
+++ b/src/services/ExploreStatsService.ts
@@ -3,6 +3,7 @@ import { ChainId } from "@juiceswapxyz/sdk-core";
 import { UniswapMulticallProvider } from "@juiceswapxyz/smart-order-router";
 import { ethers } from "ethers";
 import { PriceService, BtcPriceData, BtcPriceHistory } from "./PriceService";
+import { errorFields } from "../utils/errorFields";
 import { getPonderClient } from "./PonderClient";
 import { getChainContracts } from "../config/contracts";
 import { getChainName } from "../config/chains";
@@ -332,11 +333,11 @@ export class ExploreStatsService {
       this.fetchRecentSwaps(ponderClient, chainId),
       this.fetchPoolActivities(ponderClient, chainId),
       this.priceService.getBtcPriceData().catch((err) => {
-        this.logger.warn({ error: err }, "Failed to fetch BTC price data");
+        this.logger.warn(errorFields(err), "Failed to fetch BTC price data");
         return { price: 0, change1h: 0, change24h: 0 } as BtcPriceData;
       }),
       this.priceService.getBtcPriceHistory().catch((err) => {
-        this.logger.warn({ error: err }, "Failed to fetch BTC price history");
+        this.logger.warn(errorFields(err), "Failed to fetch BTC price history");
         return null;
       }),
       this.getYearlyVolumeStats(ponderClient, chainId),

--- a/src/services/PriceService.ts
+++ b/src/services/PriceService.ts
@@ -2,6 +2,7 @@ import axios from "axios";
 import Logger from "bunyan";
 import { ChainId, WETH9 } from "@juiceswapxyz/sdk-core";
 import { getChainContracts } from "../config/contracts";
+import { errorFields } from "../utils/errorFields";
 
 interface PriceCache {
   price: number;
@@ -44,11 +45,14 @@ export class PriceService {
   private logger: Logger;
   private btcPriceCache: PriceCache | null = null;
   private btcPriceInflight: Promise<number> | null = null;
+  private btcPriceErrorUntil: number = 0;
   private btcPriceDataCache: BtcPriceDataCache | null = null;
   private btcPriceDataInflight: Promise<BtcPriceData> | null = null;
+  private btcPriceDataErrorUntil: number = 0;
   private btcPriceHistoryCache: BtcPriceHistoryCache | null = null;
   private btcPriceHistoryInflight: Promise<BtcPriceHistory | null> | null =
     null;
+  private btcPriceHistoryErrorUntil: number = 0;
   private readonly CACHE_TTL = 300_000; // 5 minutes
   private readonly coinGeckoHeaders: Record<string, string>;
 
@@ -115,6 +119,11 @@ export class PriceService {
       return this.btcPriceCache.price;
     }
 
+    if (now < this.btcPriceErrorUntil) {
+      if (this.btcPriceCache) return this.btcPriceCache.price;
+      throw new Error("BTC price unavailable (backing off after error)");
+    }
+
     // If a getBtcPriceData() fetch is already inflight, piggyback on it
     // instead of making a separate /simple/price request
     if (this.btcPriceDataInflight) {
@@ -147,6 +156,11 @@ export class PriceService {
       return this.btcPriceDataCache.data;
     }
 
+    if (now < this.btcPriceDataErrorUntil) {
+      if (this.btcPriceDataCache) return this.btcPriceDataCache.data;
+      throw new Error("BTC price data unavailable (backing off after error)");
+    }
+
     if (this.btcPriceDataInflight) {
       return this.btcPriceDataInflight;
     }
@@ -170,6 +184,10 @@ export class PriceService {
       now - this.btcPriceHistoryCache.timestamp < this.CACHE_TTL
     ) {
       return this.btcPriceHistoryCache.data;
+    }
+
+    if (now < this.btcPriceHistoryErrorUntil) {
+      return this.btcPriceHistoryCache?.data ?? null;
     }
 
     if (this.btcPriceHistoryInflight) {
@@ -221,8 +239,9 @@ export class PriceService {
       );
       return data;
     } catch (error) {
+      this.btcPriceHistoryErrorUntil = Date.now() + this.CACHE_TTL;
       this.logger.warn(
-        { error },
+        errorFields(error),
         "Failed to fetch BTC price history from CoinGecko",
       );
       if (this.btcPriceHistoryCache) {
@@ -244,7 +263,7 @@ export class PriceService {
       return data;
     } catch (error) {
       this.logger.warn(
-        { error },
+        errorFields(error),
         "CoinGecko BTC price data fetch failed, falling back to Binance (no % changes)",
       );
       try {
@@ -254,8 +273,9 @@ export class PriceService {
         this.btcPriceCache = { price, timestamp: now };
         return data;
       } catch (fallbackError) {
+        this.btcPriceDataErrorUntil = Date.now() + this.CACHE_TTL;
         this.logger.error(
-          { error: fallbackError },
+          errorFields(fallbackError),
           "Both BTC price data sources failed",
         );
         if (this.btcPriceDataCache) {
@@ -310,7 +330,7 @@ export class PriceService {
       return price;
     } catch (error) {
       this.logger.warn(
-        { error },
+        errorFields(error),
         "CoinGecko BTC price fetch failed, trying Binance",
       );
       try {
@@ -318,8 +338,9 @@ export class PriceService {
         this.btcPriceCache = { price, timestamp: now };
         return price;
       } catch (fallbackError) {
+        this.btcPriceErrorUntil = Date.now() + this.CACHE_TTL;
         this.logger.error(
-          { error: fallbackError },
+          errorFields(fallbackError),
           "Both BTC price sources failed",
         );
         // Return stale cache if available

--- a/src/utils/errorFields.ts
+++ b/src/utils/errorFields.ts
@@ -1,0 +1,37 @@
+/**
+ * Serializes an unknown caught value into plain enumerable fields suitable for
+ * structured loggers (Bunyan, Pino, etc.).
+ *
+ * Using `{ error: e }` directly causes two problems:
+ *  1. Error properties (message, stack) are non-enumerable — Bunyan logs `{}`.
+ *  2. Grafana promotes any log entry that contains an `error` key to ERROR
+ *     level, regardless of the actual log level.
+ *
+ * Usage:
+ *   logger.warn({ ...errorFields(e) }, "Something failed, using default");
+ */
+export function errorFields(error: unknown): {
+  errMessage: string | undefined;
+  errCode: string | number | undefined;
+  errReason: string | undefined;
+  errStatus: number | undefined;
+  rpcMessage: string | undefined;
+  rpcCode: number | undefined;
+} {
+  const e = error as {
+    message?: string;
+    code?: string | number;
+    reason?: string;
+    status?: number;
+    error?: { message?: string; code?: number };
+  };
+
+  return {
+    errMessage: e?.message,
+    errCode: e?.code,
+    errReason: e?.reason,
+    errStatus: e?.status,
+    rpcMessage: e?.error?.message,
+    rpcCode: e?.error?.code,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `src/utils/errorFields.ts`: a small helper that extracts serializable fields from a caught error so structured loggers don't emit `"error":{}` and Grafana doesn't misclassify the entry as ERROR based on a field named `error`.
- Fixes all remaining `{ error }` / `{ error: e }` usages in `PriceService` and `ExploreStatsService`.
- Adds per-endpoint error backoff timestamps (`btcPriceErrorUntil`, `btcPriceDataErrorUntil`, `btcPriceHistoryErrorUntil`) to `PriceService` so a cold-start CoinGecko 429 doesn't fan out repeated requests — each failed fetch backs off for one full `CACHE_TTL` (5 min).