### PR TITLE
fix: use ERC4626 share price for svJUSD instead of hardcoded $1.00

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -328,7 +328,11 @@ async function bootstrap() {
     routerService,
     logger,
   );
-  const exploreStatsService = new ExploreStatsService(providers, logger);
+  const exploreStatsService = new ExploreStatsService(
+    providers,
+    logger,
+    svJusdPriceService,
+  );
   initializeResolvers(routerService, logger, exploreStatsService);
   const handlePoolDetails = createPoolDetailsHandler(
     providers,

--- a/src/services/ExploreStatsService.ts
+++ b/src/services/ExploreStatsService.ts
@@ -3,6 +3,7 @@ import { ChainId } from "@juiceswapxyz/sdk-core";
 import { UniswapMulticallProvider } from "@juiceswapxyz/smart-order-router";
 import { ethers } from "ethers";
 import { PriceService, BtcPriceData, BtcPriceHistory } from "./PriceService";
+import { SvJusdPriceService } from "./SvJusdPriceService";
 import { errorFields } from "../utils/errorFields";
 import { getPonderClient } from "./PonderClient";
 import { getChainContracts } from "../config/contracts";
@@ -212,9 +213,13 @@ export class ExploreStatsService {
   constructor(
     providers: Map<ChainId, ethers.providers.StaticJsonRpcProvider>,
     logger: Logger,
+    svJusdPriceService?: SvJusdPriceService,
   ) {
     this.logger = logger.child({ service: "ExploreStatsService" });
     this.priceService = new PriceService(logger);
+    if (svJusdPriceService) {
+      this.priceService.setSvJusdPriceService(svJusdPriceService);
+    }
     this.providers = providers;
   }
 
@@ -1870,7 +1875,10 @@ export class ExploreStatsService {
       if (category === "BTC") {
         pctChange1h.set(addr, btcPriceData.change1h);
         pctChange24h.set(addr, btcPriceData.change24h);
-      } else if (category === "STABLECOIN") {
+      } else if (
+        category === "STABLECOIN" ||
+        category === "ERC4626_STABLECOIN"
+      ) {
         pctChange1h.set(addr, 0);
         pctChange24h.set(addr, 0);
       }
@@ -1915,7 +1923,10 @@ export class ExploreStatsService {
       // Fallback: if no pool activity, the pool ratio hasn't changed, so the
       // token's USD price change equals the counterpart's USD price change.
       if (!activities || activities.length === 0) {
-        if (knownCategory === "STABLECOIN") {
+        if (
+          knownCategory === "STABLECOIN" ||
+          knownCategory === "ERC4626_STABLECOIN"
+        ) {
           // Paired with stablecoin, no trades → price is constant → 0%
           pctChange1h.set(addr, 0);
           pctChange24h.set(addr, 0);
@@ -1956,8 +1967,11 @@ export class ExploreStatsService {
 
         // Determine historical counterpart price
         let historicalCounterpartPrice: number;
-        if (knownCategory === "STABLECOIN") {
-          historicalCounterpartPrice = 1.0;
+        if (
+          knownCategory === "STABLECOIN" ||
+          knownCategory === "ERC4626_STABLECOIN"
+        ) {
+          historicalCounterpartPrice = prices.get(knownPriceAddr) ?? 1.0;
         } else if (knownCategory === "BTC") {
           historicalCounterpartPrice = historicalBtcPrice;
         } else {
@@ -2099,12 +2113,13 @@ export class ExploreStatsService {
       const addr = token.address.toLowerCase();
       const category = this.priceService.getTokenCategory(chainId, addr);
 
-      if (category === "STABLECOIN") {
+      if (category === "STABLECOIN" || category === "ERC4626_STABLECOIN") {
+        const stablePrice = prices.get(addr) ?? 1.0;
         result.set(addr, {
           start,
           end,
           step,
-          values: Array(bucketCount).fill(1.0),
+          values: Array(bucketCount).fill(stablePrice),
         });
         continue;
       }
@@ -2186,8 +2201,11 @@ export class ExploreStatsService {
 
           // Determine counterpart price at this time
           let counterpartPrice: number;
-          if (knownCategory === "STABLECOIN") {
-            counterpartPrice = 1.0;
+          if (
+            knownCategory === "STABLECOIN" ||
+            knownCategory === "ERC4626_STABLECOIN"
+          ) {
+            counterpartPrice = prices.get(knownPriceAddr) ?? 1.0;
           } else if (knownCategory === "BTC" && btcPriceHistory) {
             counterpartPrice = this.interpolateBtcPrice(
               btcPriceHistory,

--- a/src/services/PriceService.ts
+++ b/src/services/PriceService.ts
@@ -1,8 +1,10 @@
 import axios from "axios";
 import Logger from "bunyan";
 import { ChainId, WETH9 } from "@juiceswapxyz/sdk-core";
+import { ethers } from "ethers";
 import { getChainContracts } from "../config/contracts";
 import { errorFields } from "../utils/errorFields";
+import { SvJusdPriceService } from "./SvJusdPriceService";
 
 interface PriceCache {
   price: number;
@@ -32,7 +34,7 @@ interface BtcPriceHistoryCache {
 /**
  * Known token categories for price resolution
  */
-type TokenCategory = "BTC" | "STABLECOIN";
+type TokenCategory = "BTC" | "STABLECOIN" | "ERC4626_STABLECOIN";
 
 /**
  * PriceService - Fetches and caches token prices for TVL/volume calculations
@@ -62,6 +64,12 @@ export class PriceService {
   // Known stablecoin tokens by chain (lowercased addresses)
   private stablecoinTokens: Map<number, Set<string>> = new Map();
 
+  // ERC4626 vault stablecoins (e.g. svJUSD) — priced via share price, not $1.00
+  private erc4626StablecoinTokens: Map<number, Set<string>> = new Map();
+
+  // Optional: SvJusdPriceService for on-chain share price lookups
+  private svJusdPriceService: SvJusdPriceService | null = null;
+
   constructor(logger: Logger) {
     this.logger = logger.child({ service: "PriceService" });
     this.coinGeckoHeaders = { accept: "application/json" };
@@ -72,6 +80,14 @@ export class PriceService {
     this.initializeKnownTokens();
   }
 
+  /**
+   * Inject SvJusdPriceService for on-chain ERC4626 share price lookups.
+   * Must be called after construction to enable svJUSD pricing.
+   */
+  setSvJusdPriceService(service: SvJusdPriceService): void {
+    this.svJusdPriceService = service;
+  }
+
   private initializeKnownTokens(): void {
     for (const chainId of [ChainId.CITREA_MAINNET, ChainId.CITREA_TESTNET]) {
       const contracts = getChainContracts(chainId);
@@ -79,6 +95,7 @@ export class PriceService {
 
       const btcSet = new Set<string>();
       const stableSet = new Set<string>();
+      const erc4626Set = new Set<string>();
 
       // BTC-pegged tokens
       if (wcbtc) {
@@ -93,15 +110,18 @@ export class PriceService {
       // Stablecoin tokens
       if (contracts) {
         if (contracts.JUSD) stableSet.add(contracts.JUSD.toLowerCase());
-        if (contracts.SV_JUSD) stableSet.add(contracts.SV_JUSD.toLowerCase());
         if (contracts.USDC) stableSet.add(contracts.USDC.toLowerCase());
         if (contracts.USDT) stableSet.add(contracts.USDT.toLowerCase());
         if (contracts.CTUSD) stableSet.add(contracts.CTUSD.toLowerCase());
         if (contracts.SUSD) stableSet.add(contracts.SUSD.toLowerCase());
+
+        // svJUSD is an ERC4626 vault — price = $1 × sharePrice, not flat $1
+        if (contracts.SV_JUSD) erc4626Set.add(contracts.SV_JUSD.toLowerCase());
       }
 
       this.btcTokens.set(chainId, btcSet);
       this.stablecoinTokens.set(chainId, stableSet);
+      this.erc4626StablecoinTokens.set(chainId, erc4626Set);
     }
   }
 
@@ -360,6 +380,8 @@ export class PriceService {
   getTokenCategory(chainId: number, address: string): TokenCategory | null {
     const addr = address.toLowerCase();
     if (this.btcTokens.get(chainId)?.has(addr)) return "BTC";
+    if (this.erc4626StablecoinTokens.get(chainId)?.has(addr))
+      return "ERC4626_STABLECOIN";
     if (this.stablecoinTokens.get(chainId)?.has(addr)) return "STABLECOIN";
     return null;
   }
@@ -375,6 +397,8 @@ export class PriceService {
         return this.getBtcPriceUsd();
       case "STABLECOIN":
         return 1.0;
+      case "ERC4626_STABLECOIN":
+        return this.getErc4626StablecoinPrice(chainId);
       default:
         // Unknown token - return 0 (caller can derive from pool ratios)
         return 0;
@@ -391,6 +415,7 @@ export class PriceService {
   ): Promise<Map<string, number>> {
     const prices = new Map<string, number>();
     let btcPrice: number | null = null;
+    let erc4626Price: number | null = null;
 
     for (const addr of tokenAddresses) {
       const lowerAddr = addr.toLowerCase();
@@ -406,6 +431,12 @@ export class PriceService {
         case "STABLECOIN":
           prices.set(lowerAddr, 1.0);
           break;
+        case "ERC4626_STABLECOIN":
+          if (erc4626Price === null) {
+            erc4626Price = await this.getErc4626StablecoinPrice(chainId);
+          }
+          prices.set(lowerAddr, erc4626Price);
+          break;
         default:
           prices.set(lowerAddr, 0);
           break;
@@ -413,6 +444,32 @@ export class PriceService {
     }
 
     return prices;
+  }
+
+  /**
+   * Get USD price for an ERC4626 vault stablecoin (svJUSD).
+   * Price = $1.00 × sharePrice (JUSD per svJUSD).
+   * Falls back to $1.00 if SvJusdPriceService is not available.
+   */
+  private async getErc4626StablecoinPrice(chainId: number): Promise<number> {
+    if (!this.svJusdPriceService) {
+      this.logger.warn(
+        "SvJusdPriceService not injected, falling back to $1.00 for svJUSD",
+      );
+      return 1.0;
+    }
+    try {
+      const sharePrice = await this.svJusdPriceService.getSharePrice(
+        chainId as ChainId,
+      );
+      return parseFloat(ethers.utils.formatEther(sharePrice));
+    } catch (error) {
+      this.logger.warn(
+        errorFields(error),
+        "Failed to fetch svJUSD share price, falling back to $1.00",
+      );
+      return 1.0;
+    }
   }
 
   private async fetchBtcPriceCoinGecko(): Promise<number> {


### PR DESCRIPTION
## Summary

svJUSD is an **ERC4626 vault token** (Savings Vault JUSD). Unlike regular stablecoins, its value is not pegged at $1.00 — it equals `JUSD × sharePrice`, where the share price increases over time as interest accrues in the vault.

**Current on-chain share price: ~1.0254 JUSD per svJUSD** (and growing).

`PriceService` incorrectly categorized svJUSD as a flat `STABLECOIN`, returning a hardcoded `$1.00` for all TVL, volume, and price calculations. This means every metric involving svJUSD has been understated by the share price margin (~2.5% today, increasing over time).

## Root cause

`PriceService.initializeKnownTokens()` added svJUSD to the `stablecoinTokens` set (line 96). Every downstream consumer then received `$1.00`:

- `getTokenPriceUsd()` → `case "STABLECOIN": return 1.0`
- `getTokenPrices()` → `prices.set(addr, 1.0)` for all stablecoins
- `ExploreStatsService` used these prices for TVL, volume, sparklines, and % changes

Meanwhile, `SvJusdPriceService` already correctly fetched the real share price via `convertToAssets(1e18)` — but it was only wired to the `/v1/svjusd/sharePrice` endpoint and LP operations. The two services were completely isolated.

## What this PR changes

### 1. New token category: `ERC4626_STABLECOIN`

`PriceService` now has three categories instead of two:

| Category | Tokens | Price source |
|----------|--------|-------------|
| `BTC` | WcBTC, syBTC | CoinGecko / Binance |
| `STABLECOIN` | JUSD, USDC, USDT, CTUSD, SUSD | Hardcoded `$1.00` |
| `ERC4626_STABLECOIN` | **svJUSD** | On-chain `convertToAssets(1e18)` via `SvJusdPriceService` |

svJUSD is removed from the flat stablecoin set and placed into its own category.

### 2. `PriceService` gets `SvJusdPriceService` injection

A new `setSvJusdPriceService()` method allows injecting the existing service. When `getTokenPriceUsd()` or `getTokenPrices()` encounters an `ERC4626_STABLECOIN`, it calls `SvJusdPriceService.getSharePrice()` and returns the float value (e.g. `1.0254`). Falls back to `$1.00` if the service is unavailable.

### 3. `ExploreStatsService` wired up

The constructor now accepts an optional `SvJusdPriceService` and passes it through to its internal `PriceService`. All 6 locations in `ExploreStatsService` where `category === "STABLECOIN"` led to hardcoded behavior are updated:

| Location | Before | After |
|----------|--------|-------|
| Price % changes (1h/24h) | `0%` for all stablecoins | `0%` for stablecoins + ERC4626 (interest accrual is negligible over 24h) |
| No-activity fallback | `0%` for stablecoin-paired tokens | Same, includes ERC4626 |
| Historical counterpart price | `1.0` | Uses resolved price from `prices` map (e.g. `1.0254`) |
| Sparkline generation | `Array(24).fill(1.0)` | `Array(24).fill(resolvedPrice)` — uses actual share price |
| Derived sparkline counterpart | `1.0` | Uses resolved price from `prices` map |

### 4. `server.ts` passes `svJusdPriceService` to `ExploreStatsService`

The already-instantiated `svJusdPriceService` (used for the share price endpoint) is now also passed to `ExploreStatsService`, closing the gap.

## Impact

All endpoints that use `ExploreStatsService` or `PriceService` for USD calculations:

- `/v1/explore/stats` — token prices, pool TVL, volume in USD
- `/v1/pools/v3/details` — pool TVL
- `/v1/protocol/stats` — protocol-wide TVL
- `/v1/pools/{address}/price-history` — sparkline data
- Any pool containing svJUSD (e.g. svJUSD/WCBTC)

**Example**: svJUSD/WCBTC pool TVL was reported as ~$185K → actual value ~$189.7K.

## What this PR does NOT change

- LP operations (`lpCreate`, `lpIncrease`, `lpDecrease`) — already use `SvJusdPriceService` correctly
- `/v1/svjusd/sharePrice` endpoint — unchanged
- Frontend (bapp) — already fetches share price via API hook, no changes needed
- Ponder indexer — stores raw token amounts, no price logic

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run build` — success
- [x] `npm test` — 28/28 tests pass
- [ ] Verify svJUSD price on `/v1/explore/stats` shows ~$1.025 instead of $1.00
- [ ] Verify svJUSD/WCBTC pool TVL increases by ~2.5%
- [ ] Verify svJUSD sparkline shows flat line at ~$1.025 instead of $1.00

Closes https://github.com/JuiceSwapxyz/bapp/issues/735