### PR TITLE
Route CoinGecko via the in-cluster pricing proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,3 +72,11 @@ LDS_PONDER_URL=https://lightning.space/v1/claim
 # Get credentials from: https://app.pinata.cloud/developers/api-keys
 PINATA_API_KEY=your_pinata_api_key
 PINATA_SECRET_KEY=your_pinata_secret_key
+
+# CoinGecko: set EITHER a base URL pointing at a fronting pricing proxy (which
+# injects the upstream key itself, recommended for in-cluster deployments) OR a
+# direct Pro key. Setting only COINGECKO_BASE_URL is the cleanest setup; setting
+# only COINGECKO_API_KEY routes through pro-api.coingecko.com directly. Leaving
+# both unset falls back to the unauthenticated public endpoint.
+# COINGECKO_BASE_URL=http://pricing-proxy:8080/coingecko
+# COINGECKO_API_KEY=

--- a/src/services/PriceService.ts
+++ b/src/services/PriceService.ts
@@ -56,6 +56,7 @@ export class PriceService {
     null;
   private btcPriceHistoryErrorUntil: number = 0;
   private readonly CACHE_TTL = 300_000; // 5 minutes
+  private readonly coinGeckoBaseUrl: string;
   private readonly coinGeckoHeaders: Record<string, string>;
 
   // Known BTC-pegged tokens by chain (lowercased addresses)
@@ -72,10 +73,25 @@ export class PriceService {
 
   constructor(logger: Logger) {
     this.logger = logger.child({ service: "PriceService" });
-    this.coinGeckoHeaders = { accept: "application/json" };
+    // Resolution priority:
+    //  1. COINGECKO_BASE_URL set → trust the caller (typically an in-cluster
+    //     pricing proxy that injects the upstream key itself); no auth header.
+    //  2. COINGECKO_API_KEY set → Pro tier: pro-api.coingecko.com with the
+    //     `x-cg-pro-api-key` header. The earlier setup of public host plus
+    //     `x-cg-demo-api-key` was wrong for Pro keys: CoinGecko ignored the
+    //     auth and the calls fell into the anonymous IP-shared quota, which
+    //     produced sporadic 429s under load.
+    //  3. Otherwise → unauthenticated public endpoint.
     const apiKey = process.env.COINGECKO_API_KEY;
-    if (apiKey) {
-      this.coinGeckoHeaders["x-cg-demo-api-key"] = apiKey;
+    const baseUrl = process.env.COINGECKO_BASE_URL;
+    this.coinGeckoHeaders = { accept: "application/json" };
+    if (baseUrl) {
+      this.coinGeckoBaseUrl = baseUrl;
+    } else if (apiKey) {
+      this.coinGeckoBaseUrl = "https://pro-api.coingecko.com";
+      this.coinGeckoHeaders["x-cg-pro-api-key"] = apiKey;
+    } else {
+      this.coinGeckoBaseUrl = "https://api.coingecko.com";
     }
     this.initializeKnownTokens();
   }
@@ -225,7 +241,7 @@ export class PriceService {
   private async fetchBtcPriceHistory(): Promise<BtcPriceHistory | null> {
     try {
       const response = await axios.get(
-        "https://api.coingecko.com/api/v3/coins/bitcoin/market_chart",
+        `${this.coinGeckoBaseUrl}/api/v3/coins/bitcoin/market_chart`,
         {
           params: { vs_currency: "usd", days: 1 },
           headers: this.coinGeckoHeaders,
@@ -310,7 +326,7 @@ export class PriceService {
 
   private async fetchBtcPriceDataCoinGecko(): Promise<BtcPriceData> {
     const response = await axios.get(
-      "https://api.coingecko.com/api/v3/coins/bitcoin",
+      `${this.coinGeckoBaseUrl}/api/v3/coins/bitcoin`,
       {
         params: {
           localization: false,
@@ -474,7 +490,7 @@ export class PriceService {
 
   private async fetchBtcPriceCoinGecko(): Promise<number> {
     const response = await axios.get(
-      "https://api.coingecko.com/api/v3/simple/price",
+      `${this.coinGeckoBaseUrl}/api/v3/simple/price`,
       {
         params: { ids: "bitcoin", vs_currencies: "usd" },
         headers: this.coinGeckoHeaders,


### PR DESCRIPTION
## Summary
- \`PriceService\` was sending Pro keys to \`api.coingecko.com\` with the demo header (\`x-cg-demo-api-key\`). CoinGecko ignored that combination, so the calls fell into the anonymous IP-shared quota and produced sporadic 429s under load — same anti-pattern that JuiceDollar/monitoring had before its recent fix.
- New \`COINGECKO_BASE_URL\` env var: when set, requests go to that origin (typically the in-cluster pricing proxy that injects the upstream key itself) and no auth header is added.
- \`COINGECKO_API_KEY\` without a base URL now correctly routes to \`pro-api.coingecko.com\` with the \`x-cg-pro-api-key\` header.
- Anonymous public host stays the no-key fallback.
- The Binance fallback path is unchanged and still kicks in if CoinGecko is unreachable.

All three CoinGecko endpoint URLs (\`/coins/bitcoin\`, \`/coins/bitcoin/market_chart\`, \`/simple/price\`) now derive from a single resolved base, so future moves are a one-line change.

## Resolution priority
1. \`COINGECKO_BASE_URL\` set → proxy mode, no key sent from this service.
2. \`COINGECKO_API_KEY\` set → \`pro-api.coingecko.com\` + \`x-cg-pro-api-key\`.
3. Neither set → \`api.coingecko.com\` unauthenticated.

## Test plan
- [ ] Lint (\`npm run lint\`) passes for the changed file.
- [ ] Deploy to dev with \`COINGECKO_BASE_URL=http://pricing-proxy:8080/coingecko\` and no \`COINGECKO_API_KEY\` — confirm BTC price log shows success and no 429 in the next 24 h.
- [ ] Backwards compat: with only \`COINGECKO_API_KEY\` set (no base URL), confirm calls go to \`pro-api.coingecko.com\` via the Pro header.
- [ ] Force CoinGecko unreachable (e.g. block the proxy) and confirm the existing Binance fallback still serves the BTC price.