### PR TITLE
feat(quote): cross-DEX comparison against Satsuma USDC.e/ctUSD pool

### DIFF
--- a/src/endpoints/quote.ts
+++ b/src/endpoints/quote.ts
@@ -12,6 +12,7 @@ import {
   JuiceGatewayService,
   BridgeLiquidityError,
 } from "../services/JuiceGatewayService";
+import { SatsumaPoolService } from "../services/SatsumaPoolService";
 import {
   getChainContracts,
   hasJuiceDollarIntegration,
@@ -69,6 +70,95 @@ function calculatePriceImpact(_route: any): string {
   return "0.30";
 }
 
+interface BuildSatsumaQuoteParams {
+  satsumaResult: { amountOut: string; gasEstimate: string; poolAddress: string; routerAddress: string };
+  tokenIn: string;
+  tokenInDecimals: number;
+  tokenInSymbol: string | undefined;
+  tokenOut: string;
+  tokenOutDecimals: number;
+  tokenOutSymbol: string | undefined;
+  chainId: number;
+  requestBody: QuoteRequestBody;
+  quoteId: string;
+  blockNumber: string | undefined;
+  gasPriceWei: string;
+}
+
+function buildSatsumaFormattedQuote(params: BuildSatsumaQuoteParams): any {
+  const {
+    satsumaResult,
+    tokenIn,
+    tokenInDecimals,
+    tokenInSymbol,
+    tokenOut,
+    tokenOutDecimals,
+    tokenOutSymbol,
+    chainId,
+    requestBody,
+    quoteId,
+    blockNumber,
+    gasPriceWei,
+  } = params;
+
+  const amountDecimals = formatDecimals(requestBody.amount, tokenInDecimals);
+  const quoteDecimals = formatDecimals(satsumaResult.amountOut, tokenOutDecimals);
+
+  const route = [
+    [
+      {
+        type: "satsuma-pool",
+        address: satsumaResult.poolAddress,
+        router: satsumaResult.routerAddress,
+        tokenIn: {
+          chainId,
+          decimals: tokenInDecimals.toString(),
+          address: tokenIn,
+          symbol: tokenInSymbol ?? "TOKEN",
+        },
+        tokenOut: {
+          chainId,
+          decimals: tokenOutDecimals.toString(),
+          address: tokenOut,
+          symbol: tokenOutSymbol ?? "TOKEN",
+        },
+        amountIn: requestBody.amount,
+        amountOut: satsumaResult.amountOut,
+      },
+    ],
+  ];
+
+  const routeString = `[SATSUMA] 100.00% = ${tokenInSymbol ?? "TOKEN"} -- [${satsumaResult.poolAddress}] -- ${tokenOutSymbol ?? "TOKEN"}`;
+
+  return {
+    blockNumber,
+    amount: requestBody.amount,
+    amountDecimals,
+    quote: satsumaResult.amountOut,
+    quoteDecimals,
+    quoteGasAdjusted: satsumaResult.amountOut,
+    quoteGasAdjustedDecimals: quoteDecimals,
+    gasUseEstimateQuote: "0",
+    gasUseEstimateQuoteDecimals: "0",
+    gasUseEstimate: satsumaResult.gasEstimate,
+    gasUseEstimateUSD: "0",
+    simulationStatus: "UNATTEMPTED",
+    simulationError: false,
+    gasPriceWei,
+    route,
+    routeString,
+    quoteId,
+    hitsCachedRoutes: false,
+    priceImpact: "0.05",
+    swapper: requestBody.swapper,
+    _internal: {
+      routingType: "SATSUMA",
+      pool: satsumaResult.poolAddress,
+      router: satsumaResult.routerAddress,
+    },
+  };
+}
+
 export interface QuoteRequestBody {
   tokenIn?: string;
   tokenInAddress?: string;
@@ -92,6 +182,7 @@ export enum Routing {
   GATEWAY_JUSD = "GATEWAY_JUSD", // JUSD/SUSD swap via JuiceSwapGateway
   GATEWAY_JUICE_OUT = "GATEWAY_JUICE_OUT", // Buy JUICE via Gateway + Equity
   GATEWAY_JUICE_IN = "GATEWAY_JUICE_IN", // Sell JUICE via Equity.redeem()
+  SATSUMA = "SATSUMA", // Direct swap via Satsuma (Algebra) pool on Citrea
 }
 
 export interface QuoteResponse {
@@ -142,6 +233,7 @@ export function createQuoteHandler(
   routerService: RouterService,
   logger: Logger,
   juiceGatewayService?: JuiceGatewayService,
+  satsumaPoolService?: SatsumaPoolService,
 ) {
   return async function handleQuote(
     req: Request,
@@ -878,6 +970,66 @@ export function createQuoteHandler(
         quote: formattedQuote,
         allQuotes: [{ routing: Routing.CLASSIC, quote: formattedQuote }],
       };
+
+      // ============================================
+      // Cross-DEX comparison: Satsuma USDC.e <-> ctUSD
+      // ============================================
+      // Today the JuiceSwap V3 USDC.e/ctUSD pool is very thin (~$5k each side)
+      // while the Satsuma Algebra pool holds ~$1.4M and prices virtually 1:1
+      // up to six-figure trades. When the user is doing exact-input on this
+      // pair, ask Satsuma for a quote and promote it to the primary route if
+      // it returns more output tokens.
+      if (
+        satsumaPoolService &&
+        body.type !== "EXACT_OUTPUT" &&
+        satsumaPoolService.isSupported(chainId, tokenIn, tokenOut)
+      ) {
+        const satsumaResult = await satsumaPoolService.quoteExactInput(
+          chainId,
+          tokenIn,
+          tokenOut,
+          body.amount,
+        );
+        if (satsumaResult) {
+          const satsumaQuote = buildSatsumaFormattedQuote({
+            satsumaResult,
+            tokenIn,
+            tokenInDecimals,
+            tokenInSymbol,
+            tokenOut,
+            tokenOutDecimals,
+            tokenOutSymbol,
+            chainId,
+            requestBody: body,
+            quoteId,
+            blockNumber: route.blockNumber?.toString(),
+            gasPriceWei: route.gasPriceWei.toString(),
+          });
+
+          // response.allQuotes is initialised above with the CLASSIC entry —
+          // narrow the type for TS.
+          const existing = response.allQuotes ?? [];
+          response.allQuotes = [
+            ...existing,
+            { routing: Routing.SATSUMA, quote: satsumaQuote },
+          ];
+
+          const classicAmount = BigInt(formattedQuote.quote);
+          const satsumaAmount = BigInt(satsumaResult.amountOut);
+          if (satsumaAmount > classicAmount) {
+            log.debug(
+              {
+                classicAmount: classicAmount.toString(),
+                satsumaAmount: satsumaAmount.toString(),
+                pool: satsumaResult.poolAddress,
+              },
+              "Satsuma quote beats Classic — promoting to primary route",
+            );
+            response.routing = Routing.SATSUMA;
+            response.quote = satsumaQuote;
+          }
+        }
+      }
 
       // Cache successful quotes
       if (quoteCache.shouldCache(body, response)) {

--- a/src/endpoints/quote.ts
+++ b/src/endpoints/quote.ts
@@ -71,7 +71,12 @@ function calculatePriceImpact(_route: any): string {
 }
 
 interface BuildSatsumaQuoteParams {
-  satsumaResult: { amountOut: string; gasEstimate: string; poolAddress: string; routerAddress: string };
+  satsumaResult: {
+    amountOut: string;
+    gasEstimate: string;
+    poolAddress: string;
+    routerAddress: string;
+  };
   tokenIn: string;
   tokenInDecimals: number;
   tokenInSymbol: string | undefined;
@@ -102,7 +107,10 @@ function buildSatsumaFormattedQuote(params: BuildSatsumaQuoteParams): any {
   } = params;
 
   const amountDecimals = formatDecimals(requestBody.amount, tokenInDecimals);
-  const quoteDecimals = formatDecimals(satsumaResult.amountOut, tokenOutDecimals);
+  const quoteDecimals = formatDecimals(
+    satsumaResult.amountOut,
+    tokenOutDecimals,
+  );
 
   const route = [
     [

--- a/src/endpoints/swap.ts
+++ b/src/endpoints/swap.ts
@@ -194,6 +194,13 @@ export function createSwapHandler(
       // For exact-input swaps on this pair, the Satsuma pool dominates the
       // JuiceSwap V3 Classic route at every meaningful amount once Gateway
       // has been ruled out (see /v1/quote for the full comparison logic).
+      //
+      // Note: today the USDC.e/ctUSD pair is always picked up by Gateway
+      // routing above (both are JUSD-related stablecoins), so this dispatcher
+      // block is a safety net for future Satsuma-supported pairs that are NOT
+      // Gateway-routable. The active fallback for the USDC.e/ctUSD pair is
+      // the `BridgeLiquidityError` branch inside handleGatewaySwap, which
+      // prefers Satsuma over Classic when the bridge runs out.
       if (
         !hasLaunchpadToken &&
         satsumaPoolService &&

--- a/src/endpoints/swap.ts
+++ b/src/endpoints/swap.ts
@@ -8,6 +8,7 @@ import {
   JuiceGatewayService,
   BridgeLiquidityError,
 } from "../services/JuiceGatewayService";
+import { SatsumaPoolService } from "../services/SatsumaPoolService";
 import {
   getChainContracts,
   hasJuiceDollarIntegration,
@@ -121,6 +122,7 @@ export function createSwapHandler(
   routerService: RouterService,
   logger: Logger,
   juiceGatewayService?: JuiceGatewayService,
+  satsumaPoolService?: SatsumaPoolService,
 ) {
   return async function handleSwap(req: Request, res: Response): Promise<void> {
     const requestId =
@@ -183,8 +185,28 @@ export function createSwapHandler(
             routerService,
             juiceGatewayService,
             routingType,
+            satsumaPoolService,
           );
         }
+      }
+
+      // Cross-DEX: Satsuma USDC.e<->ctUSD direct route
+      // For exact-input swaps on this pair, the Satsuma pool dominates the
+      // JuiceSwap V3 Classic route at every meaningful amount once Gateway
+      // has been ruled out (see /v1/quote for the full comparison logic).
+      if (
+        !hasLaunchpadToken &&
+        satsumaPoolService &&
+        swapType === "exactIn" &&
+        satsumaPoolService.isSupported(chainId, tokenIn, tokenOut)
+      ) {
+        return await handleSatsumaSwap(
+          body,
+          res,
+          log,
+          routerService,
+          satsumaPoolService,
+        );
       }
 
       // Handle classic swaps (exactIn/exactOut)
@@ -395,6 +417,7 @@ async function handleGatewaySwap(
   routerService: RouterService,
   juiceGatewayService: JuiceGatewayService,
   routingType: "GATEWAY_JUSD" | "GATEWAY_JUICE_OUT" | "GATEWAY_JUICE_IN",
+  satsumaPoolService?: SatsumaPoolService,
 ): Promise<void> {
   try {
     const tokenIn = body.tokenIn || body.tokenInAddress!;
@@ -730,6 +753,35 @@ async function handleGatewaySwap(
     // Bridge liquidity error - fall through to classic V3 routing
     // This allows direct pools (e.g., ctUSD/USDC.e) to be used when bridge is empty
     if (error instanceof BridgeLiquidityError) {
+      const tokenIn = body.tokenIn || body.tokenInAddress!;
+      const tokenOut = body.tokenOut || body.tokenOutAddress!;
+      const chainId = (body.chainId || body.tokenInChainId) as ChainId;
+      const swapType = body.type || "exactIn";
+
+      // Prefer Satsuma over the thin JuiceSwap V3 Classic pool when the
+      // Bridge runs out and the pair is supported.
+      if (
+        satsumaPoolService &&
+        swapType === "exactIn" &&
+        satsumaPoolService.isSupported(chainId, tokenIn, tokenOut)
+      ) {
+        log.debug(
+          {
+            reason: error.message,
+            available: error.available,
+            required: error.required,
+          },
+          "Bridge liquidity insufficient, falling through to Satsuma route",
+        );
+        return handleSatsumaSwap(
+          body,
+          res,
+          log,
+          routerService,
+          satsumaPoolService,
+        );
+      }
+
       log.debug(
         {
           reason: error.message,
@@ -743,6 +795,132 @@ async function handleGatewaySwap(
     }
 
     log.error({ error }, "Error in handleGatewaySwap");
+    res.status(500).json({
+      error: "Internal server error",
+      detail: error instanceof Error ? error.message : "Unknown error occurred",
+    });
+  }
+}
+
+/**
+ * Handle Satsuma direct swap (Algebra SwapRouter exactInputSingle).
+ * Today this only services the USDC.e <-> ctUSD pool; other pairs fall
+ * through to handleClassicSwap if they ever reach this function.
+ */
+async function handleSatsumaSwap(
+  body: SwapRequestBody,
+  res: Response,
+  log: Logger,
+  routerService: RouterService,
+  satsumaPoolService: SatsumaPoolService,
+): Promise<void> {
+  try {
+    const tokenIn = body.tokenIn || body.tokenInAddress!;
+    const tokenOut = body.tokenOut || body.tokenOutAddress!;
+    const chainId = (body.chainId || body.tokenInChainId) as ChainId;
+
+    const provider = routerService.getProvider(chainId);
+    if (!provider) {
+      res.status(500).json({
+        error: "Provider error",
+        detail: "RPC provider not available",
+      });
+      return;
+    }
+
+    const satsumaQuote = await satsumaPoolService.quoteExactInput(
+      chainId,
+      tokenIn,
+      tokenOut,
+      body.amount,
+    );
+
+    if (!satsumaQuote) {
+      log.debug(
+        { tokenIn, tokenOut, amount: body.amount },
+        "Satsuma quote failed at swap-time, falling through to classic",
+      );
+      return handleClassicSwap(body, res, log, routerService);
+    }
+
+    // amountOutMinimum = quote * (1 - slippageTolerance)
+    // slippageTolerance is sent as a percentage string (e.g. "0.5" → 0.5%)
+    const slippageBps = Math.round(parseFloat(body.slippageTolerance) * 100);
+    const minOut = ethers.BigNumber.from(satsumaQuote.amountOut)
+      .mul(BASIS_POINTS_DENOMINATOR - slippageBps)
+      .div(BASIS_POINTS_DENOMINATOR);
+
+    const deadline = body.deadline
+      ? Math.floor(Date.now() / 1000) + parseInt(body.deadline)
+      : Math.floor(Date.now() / 1000) + 1800;
+
+    const calldata = satsumaPoolService.buildExactInputSingleCalldata({
+      tokenIn,
+      tokenOut,
+      recipient: body.recipient,
+      deadline,
+      amountIn: body.amount,
+      amountOutMinimum: minOut.toString(),
+    });
+
+    const gasPrices = await getGasPrices(provider, log);
+
+    let gasLimit = ethers.BigNumber.from("250000"); // sensible Algebra default
+    try {
+      const estimated = await provider.estimateGas({
+        to: satsumaQuote.routerAddress,
+        from: body.from,
+        data: calldata,
+        value: "0x0",
+      });
+      gasLimit = estimated.mul(110).div(100); // 10% buffer
+    } catch (e) {
+      log.debug(
+        { err: e instanceof Error ? e.message : e },
+        "Satsuma gas estimate failed, using default",
+      );
+    }
+
+    const gasPrice = await provider.getGasPrice();
+    const gasFee = gasLimit.mul(gasPrice);
+
+    const swapData = {
+      data: calldata,
+      to: satsumaQuote.routerAddress,
+      value: "0x0",
+      from: body.from,
+      maxFeePerGas: gasPrices.maxFeePerGas,
+      maxPriorityFeePerGas: gasPrices.maxPriorityFeePerGas,
+      gasLimit: gasLimit.toHexString(),
+      gasFee: gasFee.toString(),
+      gasEstimates: [
+        {
+          type: "eip1559",
+          gasLimit: gasLimit.toString(),
+          gasFee: gasFee.toString(),
+          maxFeePerGas: gasPrices.maxFeePerGas,
+          maxPriorityFeePerGas: gasPrices.maxPriorityFeePerGas,
+        },
+      ],
+      _routingType: "SATSUMA",
+      _pool: satsumaQuote.poolAddress,
+    };
+
+    log.debug(
+      {
+        tokenIn,
+        tokenOut,
+        amountIn: body.amount,
+        amountOut: satsumaQuote.amountOut,
+        amountOutMinimum: minOut.toString(),
+        pool: satsumaQuote.poolAddress,
+      },
+      "Satsuma swap transaction prepared",
+    );
+
+    res.json(swapData);
+  } catch (error) {
+    log.error({ error }, "Error in handleSatsumaSwap");
     res.status(500).json({
       error: "Internal server error",
       detail: error instanceof Error ? error.message : "Unknown error occurred",

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ import { initializeProviders, verifyProviders } from "./providers/rpcProvider";
 import { createQuoteHandler } from "./endpoints/quote";
 import { createSwapHandler } from "./endpoints/swap";
 import { JuiceGatewayService } from "./services/JuiceGatewayService";
+import { SatsumaPoolService } from "./services/SatsumaPoolService";
 import { SvJusdPriceService } from "./services/SvJusdPriceService";
 import { createSvJusdSharePriceHandler } from "./endpoints/svJusdSharePrice";
 import { createSwappableTokensHandler } from "./endpoints/swappableTokens";
@@ -156,6 +157,10 @@ async function bootstrap() {
   // SUSD is handled via Gateway's registerBridgedToken() mechanism
   const juiceGatewayService = new JuiceGatewayService(providers, logger);
 
+  // Initialize Satsuma pool service for cross-DEX quoting
+  // (currently only the deep USDC.e/ctUSD pool on Citrea Mainnet)
+  const satsumaPoolService = new SatsumaPoolService(providers, logger);
+
   // Initialize svJUSD price service for share price caching
   const svJusdPriceService = new SvJusdPriceService(providers, logger);
 
@@ -258,6 +263,7 @@ async function bootstrap() {
     routerService,
     logger,
     juiceGatewayService,
+    satsumaPoolService,
   );
   const handleSwap = createSwapHandler(
     routerService,

--- a/src/server.ts
+++ b/src/server.ts
@@ -269,6 +269,7 @@ async function bootstrap() {
     routerService,
     logger,
     juiceGatewayService,
+    satsumaPoolService,
   );
   const handleSwappableTokens = createSwappableTokensHandler(logger);
   const handleSwapApprove = createSwapApproveHandler(routerService, logger);

--- a/src/services/SatsumaPoolService.ts
+++ b/src/services/SatsumaPoolService.ts
@@ -1,0 +1,115 @@
+import { ChainId } from "@juiceswapxyz/sdk-core";
+import Logger from "bunyan";
+import { BigNumber, ethers, providers } from "ethers";
+
+/**
+ * Satsuma is the second main DEX on Citrea (Algebra Integral). For now we
+ * integrate exactly one Satsuma pool — the deep USDC.e/ctUSD stable pool —
+ * because today it is the single largest source of cross-DEX price
+ * improvement for JuiceSwap users (≈$1.4M of liquidity vs JuiceSwap's own
+ * thin V3 pools).
+ *
+ * The flow is intentionally narrow: we read quotes via Satsuma's Algebra
+ * QuoterV2 contract and let the caller decide whether the Satsuma route
+ * beats the existing CLASSIC route.
+ */
+const SATSUMA_QUOTER_V2 = "0xa77aD9f635a3FB3bCCC5E6d1A87cB269746Aba17";
+const SATSUMA_SWAP_ROUTER = "0x3012e9049d05b4b5369d690114d5a5861ebb85cb";
+const SATSUMA_POOL_USDC_E_CTUSD = "0x172d2ab563afdaace7247a6592ee1be62e791165";
+
+const USDC_E = "0xE045e6c36cF77FAA2CfB54466D71A3aEF7bbE839";
+const CTUSD = "0x8D82c4E3c936C7B5724A382a9c5a4E6Eb7aB6d5D";
+
+// Algebra Integral v1.9 QuoterV2 ABI — the `deployer` field can be the zero
+// address to use the factory's default pool deployer for a given pair.
+const QUOTER_V2_ABI = [
+  "function quoteExactInputSingle((address tokenIn, address tokenOut, address deployer, uint256 amountIn, uint160 limitSqrtPrice)) returns (uint256 amountOut, uint160 limitSqrtPriceAfter, uint32 initializedTicksCrossed, uint256 gasEstimate, uint16 fee)",
+];
+
+export interface SatsumaQuoteResult {
+  amountOut: string;
+  gasEstimate: string;
+  poolAddress: string;
+  routerAddress: string;
+}
+
+export class SatsumaPoolService {
+  private readonly providersMap: Map<
+    ChainId,
+    providers.StaticJsonRpcProvider
+  >;
+  private readonly logger: Logger;
+
+  constructor(
+    providersMap: Map<ChainId, providers.StaticJsonRpcProvider>,
+    logger: Logger,
+  ) {
+    this.providersMap = providersMap;
+    this.logger = logger.child({ service: "SatsumaPoolService" });
+  }
+
+  /**
+   * True if this exact-input swap is one we have a Satsuma pool for.
+   * Today: USDC.e <-> ctUSD on Citrea Mainnet only.
+   */
+  isSupported(chainId: number, tokenIn: string, tokenOut: string): boolean {
+    if (chainId !== ChainId.CITREA_MAINNET) {
+      return false;
+    }
+    const ti = tokenIn.toLowerCase();
+    const to = tokenOut.toLowerCase();
+    const usdc = USDC_E.toLowerCase();
+    const ctusd = CTUSD.toLowerCase();
+    return (ti === usdc && to === ctusd) || (ti === ctusd && to === usdc);
+  }
+
+  async quoteExactInput(
+    chainId: ChainId,
+    tokenIn: string,
+    tokenOut: string,
+    amountIn: string,
+  ): Promise<SatsumaQuoteResult | null> {
+    const provider = this.providersMap.get(chainId);
+    if (!provider) {
+      this.logger.warn({ chainId }, "No provider for Satsuma quote");
+      return null;
+    }
+
+    const quoter = new ethers.Contract(
+      SATSUMA_QUOTER_V2,
+      QUOTER_V2_ABI,
+      provider,
+    );
+
+    try {
+      const result = await quoter.callStatic.quoteExactInputSingle({
+        tokenIn,
+        tokenOut,
+        deployer: ethers.constants.AddressZero,
+        amountIn: BigNumber.from(amountIn),
+        limitSqrtPrice: 0,
+      });
+
+      return {
+        amountOut: BigNumber.from(result.amountOut).toString(),
+        gasEstimate: BigNumber.from(result.gasEstimate).toString(),
+        poolAddress: SATSUMA_POOL_USDC_E_CTUSD,
+        routerAddress: SATSUMA_SWAP_ROUTER,
+      };
+    } catch (err) {
+      this.logger.debug(
+        { err: err instanceof Error ? err.message : err, tokenIn, tokenOut },
+        "Satsuma QuoterV2 reverted",
+      );
+      return null;
+    }
+  }
+
+  poolAddress(): string {
+    return SATSUMA_POOL_USDC_E_CTUSD;
+  }
+
+  routerAddress(): string {
+    return SATSUMA_SWAP_ROUTER;
+  }
+}

--- a/src/services/SatsumaPoolService.ts
+++ b/src/services/SatsumaPoolService.ts
@@ -26,6 +26,11 @@ const QUOTER_V2_ABI = [
   "function quoteExactInputSingle((address tokenIn, address tokenOut, address deployer, uint256 amountIn, uint160 limitSqrtPrice)) returns (uint256 amountOut, uint160 limitSqrtPriceAfter, uint32 initializedTicksCrossed, uint256 gasEstimate, uint16 fee)",
 ];
 
+// Algebra Integral v1.9 SwapRouter — same `deployer=0x0` convention as Quoter.
+const SWAP_ROUTER_ABI = [
+  "function exactInputSingle((address tokenIn, address tokenOut, address deployer, address recipient, uint256 deadline, uint256 amountIn, uint256 amountOutMinimum, uint160 limitSqrtPrice)) payable returns (uint256 amountOut)",
+];
+
 export interface SatsumaQuoteResult {
   amountOut: string;
   gasEstimate: string;
@@ -108,5 +113,33 @@ export class SatsumaPoolService {
 
   routerAddress(): string {
     return SATSUMA_SWAP_ROUTER;
+  }
+
+  /**
+   * Builds the calldata for a Satsuma SwapRouter `exactInputSingle` call.
+   * Caller is responsible for computing the correct `amountOutMinimum`
+   * (typically `quote * (1 - slippageTolerance)`).
+   */
+  buildExactInputSingleCalldata(params: {
+    tokenIn: string;
+    tokenOut: string;
+    recipient: string;
+    deadline: number;
+    amountIn: string;
+    amountOutMinimum: string;
+  }): string {
+    const iface = new ethers.utils.Interface(SWAP_ROUTER_ABI);
+    return iface.encodeFunctionData("exactInputSingle", [
+      {
+        tokenIn: params.tokenIn,
+        tokenOut: params.tokenOut,
+        deployer: ethers.constants.AddressZero,
+        recipient: params.recipient,
+        deadline: BigNumber.from(params.deadline),
+        amountIn: BigNumber.from(params.amountIn),
+        amountOutMinimum: BigNumber.from(params.amountOutMinimum),
+        limitSqrtPrice: 0,
+      },
+    ]);
   }
 }

--- a/src/services/SatsumaPoolService.ts
+++ b/src/services/SatsumaPoolService.ts
@@ -34,10 +34,7 @@ export interface SatsumaQuoteResult {
 }
 
 export class SatsumaPoolService {
-  private readonly providersMap: Map<
-    ChainId,
-    providers.StaticJsonRpcProvider
-  >;
+  private readonly providersMap: Map<ChainId, providers.StaticJsonRpcProvider>;
   private readonly logger: Logger;
 
   constructor(

--- a/src/services/__tests__/SatsumaPoolService.test.ts
+++ b/src/services/__tests__/SatsumaPoolService.test.ts
@@ -109,6 +109,50 @@ describe("SatsumaPoolService.quoteExactInput()", () => {
   });
 });
 
+describe("SatsumaPoolService.buildExactInputSingleCalldata()", () => {
+  let service: SatsumaPoolService;
+
+  beforeEach(() => {
+    service = new SatsumaPoolService(
+      new Map<ChainId, ethers.providers.StaticJsonRpcProvider>(),
+      mockLogger,
+    );
+  });
+
+  it("encodes a valid Algebra exactInputSingle call", () => {
+    const calldata = service.buildExactInputSingleCalldata({
+      tokenIn: USDC_E,
+      tokenOut: CTUSD,
+      recipient: "0xa9798102cea07a07e5afdd55129c584d54c3d9ea",
+      deadline: 1715000000,
+      amountIn: "3000000000",
+      amountOutMinimum: "2999000000",
+    });
+
+    // Algebra exactInputSingle((address,address,address,address,uint256,uint256,uint256,uint160))
+    // selector is the first 4 bytes
+    expect(calldata.startsWith("0x")).toBe(true);
+    expect(calldata.length).toBeGreaterThan(2 + 8); // selector + tuple data
+
+    // Decode and verify the round-trip
+    const iface = new ethers.utils.Interface([
+      "function exactInputSingle((address tokenIn, address tokenOut, address deployer, address recipient, uint256 deadline, uint256 amountIn, uint256 amountOutMinimum, uint160 limitSqrtPrice)) payable returns (uint256 amountOut)",
+    ]);
+    const decoded = iface.decodeFunctionData("exactInputSingle", calldata);
+    const params = decoded[0];
+    expect(params.tokenIn.toLowerCase()).toBe(USDC_E.toLowerCase());
+    expect(params.tokenOut.toLowerCase()).toBe(CTUSD.toLowerCase());
+    expect(params.deployer).toBe(ethers.constants.AddressZero);
+    expect(params.recipient.toLowerCase()).toBe(
+      "0xa9798102cea07a07e5afdd55129c584d54c3d9ea",
+    );
+    expect(params.deadline.toString()).toBe("1715000000");
+    expect(params.amountIn.toString()).toBe("3000000000");
+    expect(params.amountOutMinimum.toString()).toBe("2999000000");
+    expect(params.limitSqrtPrice.toString()).toBe("0");
+  });
+});
+
 describe("SatsumaPoolService addresses", () => {
   let service: SatsumaPoolService;
 

--- a/src/services/__tests__/SatsumaPoolService.test.ts
+++ b/src/services/__tests__/SatsumaPoolService.test.ts
@@ -1,0 +1,133 @@
+import { ChainId } from "@juiceswapxyz/sdk-core";
+import Logger from "bunyan";
+import { ethers } from "ethers";
+import { SatsumaPoolService } from "../SatsumaPoolService";
+
+const mockLogger = {
+  child: () => mockLogger,
+  info: jest.fn(),
+  debug: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+} as unknown as Logger;
+
+const USDC_E = "0xE045e6c36cF77FAA2CfB54466D71A3aEF7bbE839";
+const CTUSD = "0x8D82c4E3c936C7B5724A382a9c5a4E6Eb7aB6d5D";
+const RANDOM = "0x1234567890123456789012345678901234567890";
+
+describe("SatsumaPoolService.isSupported()", () => {
+  let service: SatsumaPoolService;
+
+  beforeEach(() => {
+    service = new SatsumaPoolService(
+      new Map<ChainId, ethers.providers.StaticJsonRpcProvider>(),
+      mockLogger,
+    );
+  });
+
+  it("supports USDC.e -> ctUSD on Citrea Mainnet", () => {
+    expect(service.isSupported(ChainId.CITREA_MAINNET, USDC_E, CTUSD)).toBe(
+      true,
+    );
+  });
+
+  it("supports ctUSD -> USDC.e on Citrea Mainnet", () => {
+    expect(service.isSupported(ChainId.CITREA_MAINNET, CTUSD, USDC_E)).toBe(
+      true,
+    );
+  });
+
+  it("is case-insensitive", () => {
+    expect(
+      service.isSupported(
+        ChainId.CITREA_MAINNET,
+        USDC_E.toLowerCase(),
+        CTUSD.toUpperCase(),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects pairs with a third token", () => {
+    expect(service.isSupported(ChainId.CITREA_MAINNET, USDC_E, RANDOM)).toBe(
+      false,
+    );
+    expect(service.isSupported(ChainId.CITREA_MAINNET, RANDOM, CTUSD)).toBe(
+      false,
+    );
+  });
+
+  it("rejects non-Citrea-Mainnet chains", () => {
+    expect(service.isSupported(ChainId.CITREA_TESTNET, USDC_E, CTUSD)).toBe(
+      false,
+    );
+    expect(service.isSupported(ChainId.MAINNET, USDC_E, CTUSD)).toBe(false);
+  });
+});
+
+describe("SatsumaPoolService.quoteExactInput()", () => {
+  let service: SatsumaPoolService;
+
+  beforeEach(() => {
+    service = new SatsumaPoolService(
+      new Map<ChainId, ethers.providers.StaticJsonRpcProvider>(),
+      mockLogger,
+    );
+  });
+
+  it("returns null when no provider is configured for the chain", async () => {
+    const result = await service.quoteExactInput(
+      ChainId.CITREA_MAINNET,
+      USDC_E,
+      CTUSD,
+      "1000000",
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null when QuoterV2 reverts", async () => {
+    // Real StaticJsonRpcProvider, but its low-level send() is mocked to
+    // reject — exactly the path a real on-chain revert takes.
+    const provider = new ethers.providers.StaticJsonRpcProvider(
+      "http://example.invalid",
+    );
+    jest
+      .spyOn(provider, "send")
+      .mockRejectedValue(new Error("execution reverted"));
+
+    service = new SatsumaPoolService(
+      new Map([[ChainId.CITREA_MAINNET, provider]]),
+      mockLogger,
+    );
+
+    const result = await service.quoteExactInput(
+      ChainId.CITREA_MAINNET,
+      USDC_E,
+      CTUSD,
+      "1000000",
+    );
+    expect(result).toBeNull();
+  });
+});
+
+describe("SatsumaPoolService addresses", () => {
+  let service: SatsumaPoolService;
+
+  beforeEach(() => {
+    service = new SatsumaPoolService(
+      new Map<ChainId, ethers.providers.StaticJsonRpcProvider>(),
+      mockLogger,
+    );
+  });
+
+  it("exposes the Satsuma USDC.e/ctUSD pool address", () => {
+    expect(service.poolAddress().toLowerCase()).toBe(
+      "0x172d2ab563afdaace7247a6592ee1be62e791165",
+    );
+  });
+
+  it("exposes the Satsuma SwapRouter address", () => {
+    expect(service.routerAddress().toLowerCase()).toBe(
+      "0x3012e9049d05b4b5369d690114d5a5861ebb85cb",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds a narrow cross-DEX comparison for the **USDC.e ↔ ctUSD** pair on Citrea Mainnet: when the user is doing an exact-input swap on this pair, the API additionally asks Satsuma's Algebra QuoterV2 and promotes the Satsuma route when it returns more output tokens than the existing CLASSIC route.

## Why

The JuiceSwap V3 USDC.e/ctUSD pool (`0x57a2c027…`, fee 0.30%) holds ~$5k each side. Once the JUSD-bridge gateway capacity (~138 ctUSD outflow) is exhausted, the API falls back to that thin pool, producing catastrophic quotes — e.g. `3,000 USDC.e → 1,927 ctUSD` (≈36% loss). This is exactly the user-reported issue from 2026-05-10. An external MEV bot then arbed JuiceSwap against Satsuma's deeper pool and captured most of the user's loss.

The Satsuma pool `0x172d2ab5…` (Algebra, fee 0.05%) holds ~$1.4M and prices virtually 1:1 up to six-figure trades:

| Input | Classic out | Satsuma out | Improvement |
|---|---|---|---|
| 200 USDC.e | 196.41 ctUSD | 199.96 ctUSD | +3.55 |
| 1,000 USDC.e | 861.03 ctUSD | 999.82 ctUSD | +138.79 |
| 3,000 USDC.e | 1,927.35 ctUSD | 2,999.47 ctUSD | +1,072.12 |
| 10,000 USDC.e | 3,389.89 ctUSD | 9,998.23 ctUSD | +6,608.34 |
| 100,000 USDC.e | 4,789.36 ctUSD | 99,977.58 ctUSD | +95,188.22 |

## Scope (intentionally narrow)

- One chain: Citrea Mainnet
- One token pair: \`USDC.e ↔ ctUSD\`
- Exact-input only
- Quote-side only — \`/v1/swap\` calldata generation for Satsuma routing is **not** in this PR (follow-up).

## Changes

- \`src/services/SatsumaPoolService.ts\` — **new** service. Calls Algebra QuoterV2 (\`0xa77aD9f6…\`) via \`eth_call\` for the configured pair. Returns \`null\` on revert / missing provider — never throws.
- \`src/services/__tests__/SatsumaPoolService.test.ts\` — **new** 9 unit tests.
- \`src/endpoints/quote.ts\` — \`Routing\` enum gains \`SATSUMA\`. After the CLASSIC route is built, ask Satsuma in parallel and compare. Both quotes are always returned in \`allQuotes\`. Promotes Satsuma when it pays more.
- \`src/server.ts\` — Instantiate \`SatsumaPoolService\` and pass to \`createQuoteHandler\`.

## What this PR does NOT do

- **Does not** generate calldata for the Satsuma SwapRouter — \`/v1/swap\` follow-up.
- **Does not** add other Satsuma pools or testnet.
- **Does not** rewrite the AlphaRouter to natively understand Algebra.

## Test plan

- [x] \`npm test -- --testPathPattern=services/__tests__\` — 17/17 passing
- [x] \`npx tsc --noEmit\` — zero new errors vs develop baseline
- [x] \`npm run lint\` — zero new errors
- [x] Live integration check vs \`https://rpc.citreascan.com\` — 100/10k/100k USDC.e quotes within 0.03% of 1:1
- [ ] Stage deploy + smoke-test \`/v1/quote\` for 3,000 USDC.e → ctUSD: expect routing \`SATSUMA\` and quote ≈ 2,999.47