### PR TITLE
fix(quote): derive real price impact instead of returning hardcoded values

### DIFF
--- a/src/endpoints/quote.ts
+++ b/src/endpoints/quote.ts
@@ -65,17 +65,13 @@ function generateRouteString(formattedRoute: any[]): string {
   }
 }
 
-function calculatePriceImpact(_route: any): string {
-  // Simple price impact calculation - can be enhanced
-  return "0.30";
-}
-
 interface BuildSatsumaQuoteParams {
   satsumaResult: {
     amountOut: string;
     gasEstimate: string;
     poolAddress: string;
     routerAddress: string;
+    priceImpact: string;
   };
   tokenIn: string;
   tokenInDecimals: number;
@@ -157,7 +153,7 @@ function buildSatsumaFormattedQuote(params: BuildSatsumaQuoteParams): any {
     routeString,
     quoteId,
     hitsCachedRoutes: false,
-    priceImpact: "0.05",
+    priceImpact: satsumaResult.priceImpact,
     swapper: requestBody.swapper,
     _internal: {
       routingType: "SATSUMA",
@@ -812,8 +808,11 @@ export function createQuoteHandler(
       const gasUseEstimateQuoteDecimals =
         route.estimatedGasUsedQuoteToken.toExact();
 
-      // Calculate price impact
-      const priceImpact = calculatePriceImpact(route);
+      // Real price impact from the route's Trade: percent difference between
+      // the mid-price across the chosen pools and the actual execution price.
+      // String shape matches the legacy contract (Frontend parses it as a
+      // number and converts to Percent in basis points).
+      const priceImpact = route.trade.priceImpact.toFixed(2);
 
       // Build route response
       const routes = route.route;

--- a/src/services/SatsumaPoolService.ts
+++ b/src/services/SatsumaPoolService.ts
@@ -31,6 +31,14 @@ const SWAP_ROUTER_ABI = [
   "function exactInputSingle((address tokenIn, address tokenOut, address deployer, address recipient, uint256 deadline, uint256 amountIn, uint256 amountOutMinimum, uint160 limitSqrtPrice)) payable returns (uint256 amountOut)",
 ];
 
+// Algebra Integral v1.9 pool ABI — `price` is the current sqrt(token1/token0)
+// in Q64.96, the canonical zero-impact mid-price for the pool.
+const POOL_ABI = [
+  "function globalState() external view returns (uint160 price, int24 tick, uint16 lastFee, uint8 pluginConfig, uint16 communityFee, bool unlocked)",
+];
+
+const Q192 = BigNumber.from(2).pow(192);
+
 export interface SatsumaQuoteResult {
   amountOut: string;
   gasEstimate: string;
@@ -39,11 +47,6 @@ export interface SatsumaQuoteResult {
   /** Price impact as a percentage string, e.g. "0.42". May be negative. */
   priceImpact: string;
 }
-
-// 1 token of the input asset, used as a near-zero-impact reference quote so
-// we can treat its output/input ratio as the pool's mid-price. Both supported
-// tokens (USDC.e, ctUSD) have 6 decimals.
-const MID_PRICE_PROBE_AMOUNT = "1000000";
 
 export class SatsumaPoolService {
   private readonly providersMap: Map<ChainId, providers.StaticJsonRpcProvider>;
@@ -89,14 +92,18 @@ export class SatsumaPoolService {
       QUOTER_V2_ABI,
       provider,
     );
+    const pool = new ethers.Contract(
+      SATSUMA_POOL_USDC_E_CTUSD,
+      POOL_ABI,
+      provider,
+    );
 
     try {
-      // Quote the real trade and a tiny reference trade in parallel. The
-      // reference trade approximates the pool's mid-price (zero-slippage
-      // execution rate) and is used to derive a real price impact instead of
-      // returning a hardcoded value.
-      const probeAmount = BigNumber.from(MID_PRICE_PROBE_AMOUNT);
-      const [result, probeResult] = await Promise.all([
+      // Quote the real trade and read the pool's mid-price in parallel.
+      // `globalState().price` is the canonical sqrt(token1/token0) Q64.96 —
+      // the zero-impact spot price the trade would execute at if liquidity
+      // were infinite. We use it to derive the trade's true price impact.
+      const [result, state] = await Promise.all([
         quoter.callStatic.quoteExactInputSingle({
           tokenIn,
           tokenOut,
@@ -104,17 +111,10 @@ export class SatsumaPoolService {
           amountIn: BigNumber.from(amountIn),
           limitSqrtPrice: 0,
         }),
-        quoter.callStatic.quoteExactInputSingle({
-          tokenIn,
-          tokenOut,
-          deployer: ethers.constants.AddressZero,
-          amountIn: probeAmount,
-          limitSqrtPrice: 0,
-        }),
+        pool.callStatic.globalState(),
       ]);
 
       const amountOut = BigNumber.from(result.amountOut);
-      const probeOut = BigNumber.from(probeResult.amountOut);
 
       return {
         amountOut: amountOut.toString(),
@@ -122,39 +122,55 @@ export class SatsumaPoolService {
         poolAddress: SATSUMA_POOL_USDC_E_CTUSD,
         routerAddress: SATSUMA_SWAP_ROUTER,
         priceImpact: this.computePriceImpact(
+          tokenIn,
+          tokenOut,
           BigNumber.from(amountIn),
           amountOut,
-          probeAmount,
-          probeOut,
+          BigNumber.from(state.price),
         ),
       };
     } catch (err) {
       this.logger.debug(
         { err: err instanceof Error ? err.message : err, tokenIn, tokenOut },
-        "Satsuma QuoterV2 reverted",
+        "Satsuma quote or pool state read reverted",
       );
       return null;
     }
   }
 
   /**
-   * Price impact as `(expected - actual) / expected`, expressed as a
-   * percentage with 2 decimals. `expected` is derived from a small reference
-   * quote whose own impact is treated as negligible (≈$0.000001 of slippage
-   * for the actual Satsuma USDC.e/ctUSD pool today). Returns "0.00" if the
-   * probe yields no output (degenerate path) so the caller still has a
-   * truthy, well-formed string.
+   * Price impact as `(expected - actual) / expected`, in percent with 2
+   * decimals. `expected` is the zero-impact output derived from the pool's
+   * spot sqrt-price (`sqrtPriceX96`):
+   *
+   *   priceRatio (token1 per token0) = sqrtPriceX96^2 / 2^192
+   *   token1_out = token0_in * priceRatio
+   *   token0_out = token1_in / priceRatio
+   *
+   * Token ordering follows the Uniswap/Algebra convention: token0 is the
+   * lexicographically smaller address. Both currently supported tokens
+   * (USDC.e, ctUSD) have 6 decimals, so no decimal scaling is applied; if
+   * `isSupported()` is widened to mixed-decimal pairs, this needs to take
+   * decimals into account.
+   *
+   * Returns "0.00" if `sqrtPriceX96` or the expected output is zero so the
+   * caller still receives a well-formed string.
    */
   private computePriceImpact(
+    tokenIn: string,
+    tokenOut: string,
     amountIn: BigNumber,
     amountOut: BigNumber,
-    probeIn: BigNumber,
-    probeOut: BigNumber,
+    sqrtPriceX96: BigNumber,
   ): string {
-    if (probeOut.isZero() || amountIn.isZero()) {
+    if (sqrtPriceX96.isZero() || amountIn.isZero()) {
       return "0.00";
     }
-    const expectedOut = amountIn.mul(probeOut).div(probeIn);
+    const priceX192 = sqrtPriceX96.mul(sqrtPriceX96);
+    const tokenInIsToken0 = tokenIn.toLowerCase() < tokenOut.toLowerCase();
+    const expectedOut = tokenInIsToken0
+      ? amountIn.mul(priceX192).div(Q192)
+      : amountIn.mul(Q192).div(priceX192);
     if (expectedOut.isZero()) {
       return "0.00";
     }

--- a/src/services/SatsumaPoolService.ts
+++ b/src/services/SatsumaPoolService.ts
@@ -36,7 +36,14 @@ export interface SatsumaQuoteResult {
   gasEstimate: string;
   poolAddress: string;
   routerAddress: string;
+  /** Price impact as a percentage string, e.g. "0.42". May be negative. */
+  priceImpact: string;
 }
+
+// 1 token of the input asset, used as a near-zero-impact reference quote so
+// we can treat its output/input ratio as the pool's mid-price. Both supported
+// tokens (USDC.e, ctUSD) have 6 decimals.
+const MID_PRICE_PROBE_AMOUNT = "1000000";
 
 export class SatsumaPoolService {
   private readonly providersMap: Map<ChainId, providers.StaticJsonRpcProvider>;
@@ -84,19 +91,42 @@ export class SatsumaPoolService {
     );
 
     try {
-      const result = await quoter.callStatic.quoteExactInputSingle({
-        tokenIn,
-        tokenOut,
-        deployer: ethers.constants.AddressZero,
-        amountIn: BigNumber.from(amountIn),
-        limitSqrtPrice: 0,
-      });
+      // Quote the real trade and a tiny reference trade in parallel. The
+      // reference trade approximates the pool's mid-price (zero-slippage
+      // execution rate) and is used to derive a real price impact instead of
+      // returning a hardcoded value.
+      const probeAmount = BigNumber.from(MID_PRICE_PROBE_AMOUNT);
+      const [result, probeResult] = await Promise.all([
+        quoter.callStatic.quoteExactInputSingle({
+          tokenIn,
+          tokenOut,
+          deployer: ethers.constants.AddressZero,
+          amountIn: BigNumber.from(amountIn),
+          limitSqrtPrice: 0,
+        }),
+        quoter.callStatic.quoteExactInputSingle({
+          tokenIn,
+          tokenOut,
+          deployer: ethers.constants.AddressZero,
+          amountIn: probeAmount,
+          limitSqrtPrice: 0,
+        }),
+      ]);
+
+      const amountOut = BigNumber.from(result.amountOut);
+      const probeOut = BigNumber.from(probeResult.amountOut);
 
       return {
-        amountOut: BigNumber.from(result.amountOut).toString(),
+        amountOut: amountOut.toString(),
         gasEstimate: BigNumber.from(result.gasEstimate).toString(),
         poolAddress: SATSUMA_POOL_USDC_E_CTUSD,
         routerAddress: SATSUMA_SWAP_ROUTER,
+        priceImpact: this.computePriceImpact(
+          BigNumber.from(amountIn),
+          amountOut,
+          probeAmount,
+          probeOut,
+        ),
       };
     } catch (err) {
       this.logger.debug(
@@ -105,6 +135,31 @@ export class SatsumaPoolService {
       );
       return null;
     }
+  }
+
+  /**
+   * Price impact as `(expected - actual) / expected`, expressed as a
+   * percentage with 2 decimals. `expected` is derived from a small reference
+   * quote whose own impact is treated as negligible (≈$0.000001 of slippage
+   * for the actual Satsuma USDC.e/ctUSD pool today). Returns "0.00" if the
+   * probe yields no output (degenerate path) so the caller still has a
+   * truthy, well-formed string.
+   */
+  private computePriceImpact(
+    amountIn: BigNumber,
+    amountOut: BigNumber,
+    probeIn: BigNumber,
+    probeOut: BigNumber,
+  ): string {
+    if (probeOut.isZero() || amountIn.isZero()) {
+      return "0.00";
+    }
+    const expectedOut = amountIn.mul(probeOut).div(probeIn);
+    if (expectedOut.isZero()) {
+      return "0.00";
+    }
+    const bps = expectedOut.sub(amountOut).mul(10_000).div(expectedOut);
+    return (bps.toNumber() / 100).toFixed(2);
   }
 
   poolAddress(): string {

--- a/src/services/__tests__/SatsumaPoolService.test.ts
+++ b/src/services/__tests__/SatsumaPoolService.test.ts
@@ -112,10 +112,25 @@ describe("SatsumaPoolService.quoteExactInput()", () => {
     const quoterIface = new ethers.utils.Interface([
       "function quoteExactInputSingle((address tokenIn, address tokenOut, address deployer, uint256 amountIn, uint160 limitSqrtPrice)) returns (uint256 amountOut, uint160 limitSqrtPriceAfter, uint32 initializedTicksCrossed, uint256 gasEstimate, uint16 fee)",
     ]);
+    const poolIface = new ethers.utils.Interface([
+      "function globalState() external view returns (uint160 price, int24 tick, uint16 lastFee, uint8 pluginConfig, uint16 communityFee, bool unlocked)",
+    ]);
 
-    // Builds a provider whose eth_call resolves the real and probe quotes
-    // according to a caller-supplied (amountIn -> amountOut) map.
-    function buildProvider(outputs: Record<string, string>) {
+    // sqrt(1) * 2^96 — the exact mid-price of a 1:1 stable pool with equal
+    // token decimals. Used in all tests below since both USDC.e and ctUSD
+    // have 6 decimals and trade approximately 1:1 in the real Satsuma pool.
+    const SQRT_PRICE_1_TO_1 = ethers.BigNumber.from(2).pow(96).toString();
+
+    const QUOTER_ADDRESS = "0xa77ad9f635a3fb3bccc5e6d1a87cb269746aba17";
+    const POOL_ADDRESS = "0x172d2ab563afdaace7247a6592ee1be62e791165";
+
+    // Builds a provider whose eth_call dispatches to either the QuoterV2
+    // (returning a caller-supplied amountOut for the requested amountIn) or
+    // the pool (returning a caller-supplied sqrtPriceX96 for globalState).
+    function buildProvider(opts: {
+      quoteOutputs: Record<string, string>;
+      sqrtPriceX96: string;
+    }) {
       const provider = new ethers.providers.StaticJsonRpcProvider(
         "http://example.invalid",
         { name: "citrea", chainId: ChainId.CITREA_MAINNET },
@@ -126,35 +141,50 @@ describe("SatsumaPoolService.quoteExactInput()", () => {
           if (method !== "eth_call") {
             throw new Error(`Unexpected RPC call: ${method}`);
           }
-          const [tx] = params as [{ data: string }];
-          const decoded = quoterIface.decodeFunctionData(
-            "quoteExactInputSingle",
-            tx.data,
-          );
-          const amountIn = (decoded[0].amountIn as ethers.BigNumber).toString();
-          const out = outputs[amountIn];
-          if (out === undefined) {
-            throw new Error(`Unexpected amountIn: ${amountIn}`);
+          const [tx] = params as [{ data: string; to: string }];
+          const to = tx.to.toLowerCase();
+          if (to === QUOTER_ADDRESS) {
+            const decoded = quoterIface.decodeFunctionData(
+              "quoteExactInputSingle",
+              tx.data,
+            );
+            const amountIn = (
+              decoded[0].amountIn as ethers.BigNumber
+            ).toString();
+            const out = opts.quoteOutputs[amountIn];
+            if (out === undefined) {
+              throw new Error(`Unexpected amountIn: ${amountIn}`);
+            }
+            return quoterIface.encodeFunctionResult("quoteExactInputSingle", [
+              ethers.BigNumber.from(out),
+              0,
+              0,
+              ethers.BigNumber.from("100000"),
+              500,
+            ]);
           }
-          return quoterIface.encodeFunctionResult("quoteExactInputSingle", [
-            ethers.BigNumber.from(out),
-            0,
-            0,
-            ethers.BigNumber.from("100000"),
-            500,
-          ]);
+          if (to === POOL_ADDRESS) {
+            return poolIface.encodeFunctionResult("globalState", [
+              ethers.BigNumber.from(opts.sqrtPriceX96),
+              0,
+              500,
+              0,
+              0,
+              true,
+            ]);
+          }
+          throw new Error(`Unexpected eth_call target: ${tx.to}`);
         });
       return provider;
     }
 
-    it("derives real price impact from probe + actual quotes", async () => {
+    it("derives real price impact from sqrtPriceX96 + actual quote", async () => {
       // Reproduces the issue #764 trade: 3,003.416087 USDC.e -> 1,756.651830
-      // ctUSD on a pool whose mid-price (1 USDC.e -> 1 ctUSD) is essentially
-      // 1:1. Expected impact ≈ (3003.416087 - 1756.651830) / 3003.416087
-      // ≈ 41.51%.
+      // ctUSD on a pool with a 1:1 mid-price. Expected impact ≈
+      // (3003.416087 - 1756.651830) / 3003.416087 ≈ 41.51%.
       const provider = buildProvider({
-        "1000000": "1000000",
-        "3003416087": "1756651830",
+        quoteOutputs: { "3003416087": "1756651830" },
+        sqrtPriceX96: SQRT_PRICE_1_TO_1,
       });
       service = new SatsumaPoolService(
         new Map([[ChainId.CITREA_MAINNET, provider]]),
@@ -174,10 +204,10 @@ describe("SatsumaPoolService.quoteExactInput()", () => {
     });
 
     it("reports a small, non-zero impact for routine swaps", async () => {
-      // 100 USDC.e -> 99.95 ctUSD (mid-price 1:1) -> 0.05% impact
+      // 100 USDC.e -> 99.95 ctUSD on a 1:1 pool -> 0.05% impact
       const provider = buildProvider({
-        "1000000": "1000000",
-        "100000000": "99950000",
+        quoteOutputs: { "100000000": "99950000" },
+        sqrtPriceX96: SQRT_PRICE_1_TO_1,
       });
       service = new SatsumaPoolService(
         new Map([[ChainId.CITREA_MAINNET, provider]]),
@@ -195,13 +225,59 @@ describe("SatsumaPoolService.quoteExactInput()", () => {
       expect(result!.priceImpact).toBe("0.05");
     });
 
+    it("handles the reverse direction (ctUSD -> USDC.e) symmetrically", async () => {
+      // Same 1:1 pool, opposite direction. token0 in this pool is the lex-
+      // smaller address (ctUSD = 0x8D82..., USDC.e = 0xE045...), so the
+      // reverse swap exercises the token1->token0 branch of the math.
+      const provider = buildProvider({
+        quoteOutputs: { "100000000": "99950000" },
+        sqrtPriceX96: SQRT_PRICE_1_TO_1,
+      });
+      service = new SatsumaPoolService(
+        new Map([[ChainId.CITREA_MAINNET, provider]]),
+        mockLogger,
+      );
+
+      const result = await service.quoteExactInput(
+        ChainId.CITREA_MAINNET,
+        CTUSD,
+        USDC_E,
+        "100000000",
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.priceImpact).toBe("0.05");
+    });
+
+    it("reports negative price impact for positive slippage", async () => {
+      // Pool returns more than the mid-price would imply (rare, e.g. JIT
+      // liquidity rebate). Frontend formats negative impacts as "+0.05%".
+      const provider = buildProvider({
+        quoteOutputs: { "100000000": "100050000" },
+        sqrtPriceX96: SQRT_PRICE_1_TO_1,
+      });
+      service = new SatsumaPoolService(
+        new Map([[ChainId.CITREA_MAINNET, provider]]),
+        mockLogger,
+      );
+
+      const result = await service.quoteExactInput(
+        ChainId.CITREA_MAINNET,
+        USDC_E,
+        CTUSD,
+        "100000000",
+      );
+
+      expect(result!.priceImpact).toBe("-0.05");
+    });
+
     it("never falls back to the legacy hardcoded 0.05 / 0.30 strings", async () => {
       // The bug we're fixing: legacy code returned "0.05" regardless of the
       // actual trade. Use a trade where the real impact is decisively *not*
       // 0.05% (or 0.30%) so this test would have failed under the old code.
       const provider = buildProvider({
-        "1000000": "1000000",
-        "3003416087": "1756651830",
+        quoteOutputs: { "3003416087": "1756651830" },
+        sqrtPriceX96: SQRT_PRICE_1_TO_1,
       });
       service = new SatsumaPoolService(
         new Map([[ChainId.CITREA_MAINNET, provider]]),

--- a/src/services/__tests__/SatsumaPoolService.test.ts
+++ b/src/services/__tests__/SatsumaPoolService.test.ts
@@ -107,6 +107,118 @@ describe("SatsumaPoolService.quoteExactInput()", () => {
     );
     expect(result).toBeNull();
   });
+
+  describe("priceImpact", () => {
+    const quoterIface = new ethers.utils.Interface([
+      "function quoteExactInputSingle((address tokenIn, address tokenOut, address deployer, uint256 amountIn, uint160 limitSqrtPrice)) returns (uint256 amountOut, uint160 limitSqrtPriceAfter, uint32 initializedTicksCrossed, uint256 gasEstimate, uint16 fee)",
+    ]);
+
+    // Builds a provider whose eth_call resolves the real and probe quotes
+    // according to a caller-supplied (amountIn -> amountOut) map.
+    function buildProvider(outputs: Record<string, string>) {
+      const provider = new ethers.providers.StaticJsonRpcProvider(
+        "http://example.invalid",
+        { name: "citrea", chainId: ChainId.CITREA_MAINNET },
+      );
+      jest
+        .spyOn(provider, "send")
+        .mockImplementation(async (method, params) => {
+          if (method !== "eth_call") {
+            throw new Error(`Unexpected RPC call: ${method}`);
+          }
+          const [tx] = params as [{ data: string }];
+          const decoded = quoterIface.decodeFunctionData(
+            "quoteExactInputSingle",
+            tx.data,
+          );
+          const amountIn = (decoded[0].amountIn as ethers.BigNumber).toString();
+          const out = outputs[amountIn];
+          if (out === undefined) {
+            throw new Error(`Unexpected amountIn: ${amountIn}`);
+          }
+          return quoterIface.encodeFunctionResult("quoteExactInputSingle", [
+            ethers.BigNumber.from(out),
+            0,
+            0,
+            ethers.BigNumber.from("100000"),
+            500,
+          ]);
+        });
+      return provider;
+    }
+
+    it("derives real price impact from probe + actual quotes", async () => {
+      // Reproduces the issue #764 trade: 3,003.416087 USDC.e -> 1,756.651830
+      // ctUSD on a pool whose mid-price (1 USDC.e -> 1 ctUSD) is essentially
+      // 1:1. Expected impact ≈ (3003.416087 - 1756.651830) / 3003.416087
+      // ≈ 41.51%.
+      const provider = buildProvider({
+        "1000000": "1000000",
+        "3003416087": "1756651830",
+      });
+      service = new SatsumaPoolService(
+        new Map([[ChainId.CITREA_MAINNET, provider]]),
+        mockLogger,
+      );
+
+      const result = await service.quoteExactInput(
+        ChainId.CITREA_MAINNET,
+        USDC_E,
+        CTUSD,
+        "3003416087",
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.amountOut).toBe("1756651830");
+      expect(result!.priceImpact).toBe("41.51");
+    });
+
+    it("reports a small, non-zero impact for routine swaps", async () => {
+      // 100 USDC.e -> 99.95 ctUSD (mid-price 1:1) -> 0.05% impact
+      const provider = buildProvider({
+        "1000000": "1000000",
+        "100000000": "99950000",
+      });
+      service = new SatsumaPoolService(
+        new Map([[ChainId.CITREA_MAINNET, provider]]),
+        mockLogger,
+      );
+
+      const result = await service.quoteExactInput(
+        ChainId.CITREA_MAINNET,
+        USDC_E,
+        CTUSD,
+        "100000000",
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.priceImpact).toBe("0.05");
+    });
+
+    it("never falls back to the legacy hardcoded 0.05 / 0.30 strings", async () => {
+      // The bug we're fixing: legacy code returned "0.05" regardless of the
+      // actual trade. Use a trade where the real impact is decisively *not*
+      // 0.05% (or 0.30%) so this test would have failed under the old code.
+      const provider = buildProvider({
+        "1000000": "1000000",
+        "3003416087": "1756651830",
+      });
+      service = new SatsumaPoolService(
+        new Map([[ChainId.CITREA_MAINNET, provider]]),
+        mockLogger,
+      );
+
+      const result = await service.quoteExactInput(
+        ChainId.CITREA_MAINNET,
+        USDC_E,
+        CTUSD,
+        "3003416087",
+      );
+
+      expect(result!.priceImpact).not.toBe("0.05");
+      expect(result!.priceImpact).not.toBe("0.30");
+    });
+  });
 });
 
 describe("SatsumaPoolService.buildExactInputSingleCalldata()", () => {


### PR DESCRIPTION
## Summary

Fixes #764.

The Quote API has been returning a hardcoded `priceImpact` of `"0.30"` for Classic routes and `"0.05"` for Satsuma routes regardless of the actual trade. Because the frontend treats this field as authoritative (`ClassicTrade.priceImpact` uses the API value over the SDK-computed one whenever the API value is truthy), users were seeing benign-looking warnings on swaps with double-digit execution impact — including the documented case of `3,003 USDC.e -> 1,756 ctUSD` (~41.5% impact, rendered as ~0.05%).

## Changes

- **Classic**: replaced the placeholder `calculatePriceImpact()` with `route.trade.priceImpact.toFixed(2)`. `Trade.priceImpact` from `@juiceswapxyz/router-sdk` is the canonical implementation (mid-price across all sub-routes vs. execution price); no new dependencies.
- **Satsuma**: `SatsumaPoolService.quoteExactInput()` now reads the pool's `globalState().price` (`sqrtPriceX96`) in parallel with the QuoterV2 call and derives the exact zero-impact mid-price from it. Math:
  ```
  priceX192 = sqrtPriceX96²
  token1_out = token0_in × priceX192 / 2¹⁹²
  token0_out = token1_in × 2¹⁹² / priceX192
  impact = (expectedOut − actualOut) / expectedOut
  ```
  Token ordering follows the Uniswap/Algebra convention (token0 = lex-smaller address). Both currently supported tokens (USDC.e, ctUSD) have 6 decimals, so no decimal scaling is applied — if `isSupported()` is widened to mixed-decimal pairs, `computePriceImpact()` needs a decimals adjustment (noted in the code).
- Added unit tests: #764 reproduction (yields `"41.51"` against a synthetic 1:1 pool), reverse direction (token1 → token0 branch), positive slippage (negative impact), routine 0.05% trade, and a regression guard against the legacy `0.05` / `0.30` strings.

## Verification against the real Citrea pool

Decoded the on-chain `globalState()` response from pool `0x172d2ab563afdaace7247a6592ee1be62e791165`:

| Field | Value |
|---|---|
| `sqrtPriceX96` | `79221005712492923182645582742` (≈ `2⁹⁶` × `0.99991`) |
| `tick` | `-2` |
| `lastFee` | `500` (5 bps) |
| `unlocked` | `true` |

Running the new `computePriceImpact()` against this real state and the #764 trade (`3003.416087 USDC.e → 1756.651830 ctUSD`):
- expected mid-price output: `3,003.958766 ctUSD`
- actual on-chain output: `1,756.651830 ctUSD`
- **computed impact: 41.52%** — matches the issue's claimed ~41.51% to within 0.01%

This confirms the Algebra Integral v1.9 ABI is correct, the token ordering branch is hit correctly, and the math reproduces the documented incident end-to-end.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (no new warnings introduced)
- [x] `npx prettier --check` on changed files
- [x] `npm run test:unit` — 43/43 passing
- [x] `npm run build`
- [x] Real on-chain verification: decoded `globalState()` from Citrea mainnet pool, ran the new impact math against the #764 trade, got `41.52%`
- [ ] Smoke-test against DEV: confirm a real Classic quote returns a sane `priceImpact` and the issue's reproducer surfaces a >10% warning in the UI