### PR TITLE
chore(deps): bump @juiceswapxyz/smart-order-router to ^3.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@juicedollar/jusd": "^3.0.0",
         "@juiceswapxyz/router-sdk": "^3.0.4",
         "@juiceswapxyz/sdk-core": "^3.0.4",
-        "@juiceswapxyz/smart-order-router": "^3.0.4",
+        "@juiceswapxyz/smart-order-router": "^3.0.5",
         "@juiceswapxyz/universal-router-sdk": "^3.0.4",
         "@juiceswapxyz/v2-sdk": "^3.0.4",
         "@juiceswapxyz/v3-sdk": "^3.0.5",
@@ -4081,9 +4081,9 @@
       }
     },
     "node_modules/@juiceswapxyz/smart-order-router": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@juiceswapxyz/smart-order-router/-/smart-order-router-3.0.4.tgz",
-      "integrity": "sha512-rTcO1lNfqfSz9jXwA+iGGD9B7KzOLgE2OsiiXjzO0TSIW+T+ps2XZ0l2SZtk55K4p8mhJj+hzSVfsbxqlhTWcg==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@juiceswapxyz/smart-order-router/-/smart-order-router-3.0.5.tgz",
+      "integrity": "sha512-ssMMrEwLPwROdoBN5hR4TmTKObO025xQEo3WZ9Afoy1So4VGYCpkg3Vif7lOmBqDnML6/vwUQcHemLwV5DoMpQ==",
       "license": "GPL",
       "dependencies": {
         "@eth-optimism/sdk": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@juicedollar/jusd": "^3.0.0",
     "@juiceswapxyz/router-sdk": "^3.0.4",
     "@juiceswapxyz/sdk-core": "^3.0.4",
-    "@juiceswapxyz/smart-order-router": "^3.0.4",
+    "@juiceswapxyz/smart-order-router": "^3.0.5",
     "@juiceswapxyz/universal-router-sdk": "^3.0.4",
     "@juiceswapxyz/v2-sdk": "^3.0.4",
     "@juiceswapxyz/v3-sdk": "^3.0.5",


### PR DESCRIPTION
## Summary

Pulls in the log-level downgrade from [JuiceSwapxyz/smart-order-router#21](https://github.com/JuiceSwapxyz/smart-order-router/pull/21) (merged).

Three call sites in `gas-factory-helpers.ts` / `v2-heuristic-gas-model.ts` that handle "no native pool found for gas cost computation" as expected control flow (return `null`, caller falls back) now log at **warn** instead of **error**.

## Effect

Observed in production (`juiceswap-jsw-api-14` on `dfxprd`, Citrea Mainnet):

- ~27'000 Pino `level: 50` (ERROR) entries per hour from quote requests involving tokens with no native pool (`CTR`, `svJUSD`, `WBTC.e` via V2 path)
- Rate growing ~10× over 6h alongside frontend traffic
- User-facing quotes unaffected (succeed via V3 or `GATEWAY_JUSD` where pools exist)

After this bump + redeploy, ERROR rate on the container should drop to background levels.

## Blocked by

- [ ] `@juiceswapxyz/smart-order-router@3.0.5` published to npm (currently latest is 3.0.4 — the smart-order-router release workflow has separate infra issues, see [smart-order-router#22](https://github.com/JuiceSwapxyz/smart-order-router/pull/22) for the version bump and [#23](https://github.com/JuiceSwapxyz/smart-order-router/pull/23) for the CI runner fix)

## Test plan

After 3.0.5 is on npm:

- [ ] `npm install` to refresh `package-lock.json`
- [ ] Push the lockfile update to this branch
- [ ] Mark PR ready for review
- [ ] After merge + deploy: confirm in Loki that `level=50` rate on `juiceswap-jsw-api-*` drops to background