### PR TITLE
[codex] Gate JUSD Gateway deposits while Savings is disabled

### DIFF
--- a/src/adapters/handleGraphQL/resolvers.ts
+++ b/src/adapters/handleGraphQL/resolvers.ts
@@ -6,6 +6,7 @@ import {
   ExploreStatsService,
   TransactionStatsResponse,
 } from "../../services/ExploreStatsService";
+import { JuiceGatewayService } from "../../services/JuiceGatewayService";
 import { getChainName } from "../../config/chains";
 
 let quoteHandler: any;
@@ -20,8 +21,9 @@ export function initializeResolvers(
   routerService: any,
   logger: Logger,
   exploreStats?: ExploreStatsService,
+  juiceGatewayService?: JuiceGatewayService,
 ) {
-  quoteHandler = createQuoteHandler(routerService, logger);
+  quoteHandler = createQuoteHandler(routerService, logger, juiceGatewayService);
   swapsHandler = createSwapsHandler(routerService, logger);
   exploreStatsService = exploreStats ?? null;
 }

--- a/src/cache/quoteCache.ts
+++ b/src/cache/quoteCache.ts
@@ -46,7 +46,11 @@ export class QuoteCache {
   constructor(logger?: Logger) {
     this.logger = logger;
     // Start periodic cleanup
-    setInterval(() => this.cleanup(), this.CLEANUP_INTERVAL);
+    const cleanupTimer = setInterval(
+      () => this.cleanup(),
+      this.CLEANUP_INTERVAL,
+    );
+    cleanupTimer.unref();
     if (this.logger) {
       this.logger.debug(
         "[QuoteCache] Initialized with TTL: 30s default, 60s for Citrea",

--- a/src/endpoints/__tests__/gatewayDepositDisabled.test.ts
+++ b/src/endpoints/__tests__/gatewayDepositDisabled.test.ts
@@ -1,0 +1,243 @@
+import { ChainId } from "@juiceswapxyz/sdk-core";
+import Logger from "bunyan";
+import { quoteCache } from "../../cache/quoteCache";
+import { JuiceGatewayService } from "../../services/JuiceGatewayService";
+import { getChainContracts } from "../../config/contracts";
+import {
+  initializeResolvers,
+  resolvers,
+} from "../../adapters/handleGraphQL/resolvers";
+import { createLpCreateHandler } from "../lpCreate";
+import { createLpIncreaseHandler } from "../lpIncrease";
+import { createQuoteHandler, Routing } from "../quote";
+import { createSwapHandler } from "../swap";
+
+jest.mock("../../services/LaunchpadTokenService", () => ({
+  isGraduatedLaunchpadToken: jest.fn().mockResolvedValue(false),
+}));
+jest.mock("../../services/userTracking", () => ({
+  trackUser: jest.fn(),
+}));
+
+function createMockLogger(): Logger {
+  const logger = {
+    child: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+  return logger as unknown as Logger;
+}
+
+function createMockResponse() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    setHeader: jest.fn().mockReturnThis(),
+  };
+}
+
+describe("Gateway deposit disabled endpoint gating", () => {
+  const chainId = ChainId.CITREA_MAINNET;
+  const contracts = getChainContracts(chainId)!;
+  const savingsAddress = "0x0000000000000000000000000000000000000001";
+  let logger: Logger;
+  let juiceGatewayService: JuiceGatewayService;
+
+  beforeEach(() => {
+    quoteCache.clear();
+    logger = createMockLogger();
+    juiceGatewayService = new JuiceGatewayService(new Map(), logger);
+    juiceGatewayService.setSavingsRateOverride(chainId, 0, savingsAddress);
+  });
+
+  afterEach(() => {
+    quoteCache.clear();
+  });
+
+  it("returns GATEWAY_DEPOSIT_DISABLED before serving a stale cached quote", async () => {
+    const body = {
+      tokenIn: contracts.JUSD,
+      tokenOut: contracts.WCBTC,
+      tokenInChainId: chainId,
+      tokenOutChainId: chainId,
+      tokenInDecimals: 18,
+      tokenOutDecimals: 18,
+      amount: "1000000000000000000",
+      type: "EXACT_INPUT",
+      swapper: "0x000000000000000000000000000000000000dead",
+    };
+    quoteCache.set(body, {
+      requestId: "cached",
+      routing: Routing.GATEWAY_JUSD,
+      permitData: null,
+      quote: { quote: "1" },
+    });
+    const routerService = {
+      isChainSupported: jest.fn().mockReturnValue(true),
+      getQuote: jest.fn(),
+    };
+    const handler = createQuoteHandler(
+      routerService as any,
+      logger,
+      juiceGatewayService,
+    );
+    const res = createMockResponse();
+
+    await handler({ body, headers: {} } as any, res as any);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: "GATEWAY_DEPOSIT_DISABLED" }),
+    );
+    expect(routerService.getQuote).not.toHaveBeenCalled();
+  });
+
+  it("rejects JUICE input swaps before building the old multi-step calldata", async () => {
+    const body = {
+      tokenIn: contracts.JUICE,
+      tokenOut: contracts.WCBTC,
+      tokenInChainId: chainId,
+      tokenOutChainId: chainId,
+      tokenInDecimals: 18,
+      tokenOutDecimals: 18,
+      amount: "1000000000000000000",
+      type: "exactIn",
+      recipient: "0x000000000000000000000000000000000000dead",
+      from: "0x000000000000000000000000000000000000dead",
+      slippageTolerance: "0.5",
+    };
+    const routerService = {
+      getProvider: jest.fn(),
+    };
+    const handler = createSwapHandler(
+      routerService as any,
+      logger,
+      juiceGatewayService,
+    );
+    const res = createMockResponse();
+
+    await handler({ body, headers: {} } as any, res as any);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: "GATEWAY_DEPOSIT_DISABLED" }),
+    );
+    expect(routerService.getProvider).not.toHaveBeenCalled();
+  });
+
+  it("applies the same stale-cache gate to the GraphQL quote resolver", async () => {
+    const input = {
+      tokenInAddress: contracts.JUSD,
+      tokenOutAddress: contracts.WCBTC,
+      tokenInChainId: chainId,
+      tokenOutChainId: chainId,
+      amount: "1000000000000000000",
+      type: "EXACT_INPUT",
+      swapper: "0x000000000000000000000000000000000000dead",
+    };
+    quoteCache.set(
+      {
+        ...input,
+        tokenIn: undefined,
+        tokenOut: undefined,
+      },
+      {
+        requestId: "cached",
+        routing: Routing.GATEWAY_JUSD,
+        permitData: null,
+        quote: { quote: "1" },
+      },
+    );
+    const routerService = {
+      isChainSupported: jest.fn().mockReturnValue(true),
+      getQuote: jest.fn(),
+    };
+    initializeResolvers(
+      routerService as any,
+      logger,
+      undefined,
+      juiceGatewayService,
+    );
+
+    await expect(resolvers.Query.quote(null, { input })).rejects.toThrow(
+      "JUSD savings rate is zero",
+    );
+    expect(routerService.getQuote).not.toHaveBeenCalled();
+  });
+
+  it("rejects LP create with JUSD before provider or pool work", async () => {
+    const body = {
+      protocol: "V3",
+      walletAddress: "0x000000000000000000000000000000000000dead",
+      chainId,
+      independentAmount: "1000000000000000000",
+      independentToken: "TOKEN_0",
+      position: {
+        tickLower: -600,
+        tickUpper: 600,
+        pool: {
+          token0: contracts.JUSD,
+          token1: contracts.WCBTC,
+          fee: 3000,
+        },
+      },
+    };
+    const routerService = {
+      getProvider: jest.fn(),
+    };
+    const handler = createLpCreateHandler(
+      routerService as any,
+      logger,
+      juiceGatewayService,
+    );
+    const res = createMockResponse();
+
+    await handler({ body, headers: {} } as any, res as any);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: "GATEWAY_DEPOSIT_DISABLED" }),
+    );
+    expect(routerService.getProvider).not.toHaveBeenCalled();
+  });
+
+  it("rejects LP increase with bridged stable input before provider or Ponder work", async () => {
+    const body = {
+      protocol: "V3",
+      walletAddress: "0x000000000000000000000000000000000000dead",
+      chainId,
+      tokenId: "123",
+      independentAmount: "1000000",
+      independentToken: "TOKEN_0",
+      position: {
+        tickLower: -600,
+        tickUpper: 600,
+        pool: {
+          token0: contracts.USDC,
+          token1: contracts.WCBTC,
+          fee: 3000,
+        },
+      },
+    };
+    const routerService = {
+      getProvider: jest.fn(),
+    };
+    const handler = createLpIncreaseHandler(
+      routerService as any,
+      logger,
+      juiceGatewayService,
+    );
+    const res = createMockResponse();
+
+    await handler({ body, headers: {} } as any, res as any);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: "GATEWAY_DEPOSIT_DISABLED" }),
+    );
+    expect(routerService.getProvider).not.toHaveBeenCalled();
+  });
+});

--- a/src/endpoints/__tests__/gatewayDepositGuard.test.ts
+++ b/src/endpoints/__tests__/gatewayDepositGuard.test.ts
@@ -1,0 +1,95 @@
+import Logger from "bunyan";
+import {
+  isGatewayDepositDisabledError,
+  sendGatewayDepositDisabled,
+} from "../gatewayDepositGuard";
+
+function createMockLogger(): Logger {
+  const logger = {
+    child: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+  return logger as unknown as Logger;
+}
+
+function createMockResponse() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  };
+}
+
+describe("gatewayDepositGuard", () => {
+  describe("isGatewayDepositDisabledError", () => {
+    it("recognises the GATEWAY_DEPOSIT_DISABLED error", () => {
+      expect(
+        isGatewayDepositDisabledError({ code: "GATEWAY_DEPOSIT_DISABLED" }),
+      ).toBe(true);
+    });
+
+    it("rejects other errors and non-objects", () => {
+      expect(isGatewayDepositDisabledError(new Error("boom"))).toBe(false);
+      expect(isGatewayDepositDisabledError({ code: "SOMETHING_ELSE" })).toBe(
+        false,
+      );
+      expect(isGatewayDepositDisabledError(null)).toBe(false);
+      expect(isGatewayDepositDisabledError("nope")).toBe(false);
+    });
+  });
+
+  describe("sendGatewayDepositDisabled", () => {
+    it("uses the error message as the detail when present", () => {
+      const res = createMockResponse();
+      const log = createMockLogger();
+
+      sendGatewayDepositDisabled(
+        res as never,
+        log,
+        {
+          code: "GATEWAY_DEPOSIT_DISABLED",
+          message: "custom detail",
+          savingsRate: "0",
+          savingsAddress: "0xabc",
+        },
+        { chainId: 4114 },
+      );
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({
+        error: "GATEWAY_DEPOSIT_DISABLED",
+        detail: "custom detail",
+      });
+      expect(log.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          chainId: 4114,
+          savingsRate: "0",
+          savingsAddress: "0xabc",
+        }),
+        "Gateway deposit disabled",
+      );
+    });
+
+    it("falls back to the canonical detail when no message is set", () => {
+      const res = createMockResponse();
+      const log = createMockLogger();
+
+      sendGatewayDepositDisabled(
+        res as never,
+        log,
+        { code: "GATEWAY_DEPOSIT_DISABLED" },
+        {},
+      );
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({
+        error: "GATEWAY_DEPOSIT_DISABLED",
+        detail:
+          "JUSD savings rate is zero; svJUSD deposits revert while Savings is disabled.",
+      });
+    });
+  });
+});

--- a/src/endpoints/gatewayDepositGuard.ts
+++ b/src/endpoints/gatewayDepositGuard.ts
@@ -1,0 +1,51 @@
+import { Response } from "express";
+import Logger from "bunyan";
+
+/**
+ * Shared handling for the GATEWAY_DEPOSIT_DISABLED guard raised by
+ * JuiceGatewayService while the JUSD Savings rate is zero. Used by the quote,
+ * swap and LP endpoints so the error code, status and detail stay in sync.
+ */
+export interface GatewayDepositDisabledError {
+  code?: string;
+  message?: string;
+  savingsRate?: string;
+  savingsAddress?: string | null;
+}
+
+const FALLBACK_DETAIL =
+  "JUSD savings rate is zero; svJUSD deposits revert while Savings is disabled.";
+
+export function isGatewayDepositDisabledError(
+  error: unknown,
+): error is GatewayDepositDisabledError {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as GatewayDepositDisabledError).code === "GATEWAY_DEPOSIT_DISABLED"
+  );
+}
+
+/**
+ * Log the rejection (with the probed savings rate/address for the audit trail)
+ * and respond with the canonical 404 structured error.
+ */
+export function sendGatewayDepositDisabled(
+  res: Response,
+  log: Logger,
+  error: GatewayDepositDisabledError,
+  context: Record<string, unknown>,
+): void {
+  log.warn(
+    {
+      ...context,
+      savingsRate: error.savingsRate,
+      savingsAddress: error.savingsAddress,
+    },
+    "Gateway deposit disabled",
+  );
+  res.status(404).json({
+    error: "GATEWAY_DEPOSIT_DISABLED",
+    detail: error.message || FALLBACK_DETAIL,
+  });
+}

--- a/src/endpoints/lpCreate.ts
+++ b/src/endpoints/lpCreate.ts
@@ -54,6 +54,19 @@ const calculateTxValue = (
   return ethers.BigNumber.from(amount);
 };
 
+function sendGatewayDepositDisabled(
+  res: Response,
+  log: Logger,
+  context: Record<string, unknown>,
+): void {
+  log.warn(context, "Gateway LP deposit disabled");
+  res.status(404).json({
+    error: "GATEWAY_DEPOSIT_DISABLED",
+    detail:
+      "JUSD savings rate is zero; svJUSD deposits revert while Savings is disabled.",
+  });
+}
+
 type IndependentToken = "TOKEN_0" | "TOKEN_1";
 
 interface PoolInfo {
@@ -530,6 +543,40 @@ async function handleGatewayLpCreate(
   // Get token addresses (user-facing, not converted)
   const token0Addr = getTokenAddress(position.pool.token0, chainId);
   const token1Addr = getTokenAddress(position.pool.token1, chainId);
+
+  const gatewayDepositToken = [token0Addr, token1Addr].find((token) =>
+    [
+      contracts.JUSD,
+      contracts.SUSD,
+      contracts.USDC,
+      contracts.USDT,
+      contracts.CTUSD,
+      contracts.JUICE,
+    ].some((candidate) => candidate?.toLowerCase() === token.toLowerCase()),
+  );
+  if (gatewayDepositToken) {
+    try {
+      await juiceGatewayService.prepareQuote(
+        chainId as ChainId,
+        gatewayDepositToken,
+        contracts.WCBTC,
+        "1",
+      );
+    } catch (error) {
+      if ((error as { code?: string }).code === "GATEWAY_DEPOSIT_DISABLED") {
+        sendGatewayDepositDisabled(res, log, {
+          chainId,
+          token0: token0Addr,
+          token1: token1Addr,
+          savingsRate: (error as { savingsRate?: string }).savingsRate,
+          savingsAddress: (error as { savingsAddress?: string | null })
+            .savingsAddress,
+        });
+        return;
+      }
+      throw error;
+    }
+  }
 
   // Get internal pool tokens (JUSD → svJUSD)
   const internalToken0 = juiceGatewayService.getInternalPoolToken(

--- a/src/endpoints/lpCreate.ts
+++ b/src/endpoints/lpCreate.ts
@@ -224,6 +224,42 @@ export function createLpCreateHandler(
         }
       }
 
+      const token0Addr = getTokenAddress(position.pool.token0, chainId);
+      const token1Addr = getTokenAddress(position.pool.token1, chainId);
+
+      if (
+        juiceGatewayService &&
+        hasJuiceDollarIntegration(chainId) &&
+        juiceGatewayService.detectLpGatewayRouting(
+          chainId,
+          token0Addr,
+          token1Addr,
+        )
+      ) {
+        try {
+          await juiceGatewayService.rejectIfLpRouteRequiresJusdDepositDisabled(
+            chainId as ChainId,
+            token0Addr,
+            token1Addr,
+          );
+        } catch (error) {
+          if (
+            (error as { code?: string }).code === "GATEWAY_DEPOSIT_DISABLED"
+          ) {
+            sendGatewayDepositDisabled(res, log, {
+              chainId,
+              token0: token0Addr,
+              token1: token1Addr,
+              savingsRate: (error as { savingsRate?: string }).savingsRate,
+              savingsAddress: (error as { savingsAddress?: string | null })
+                .savingsAddress,
+            });
+            return;
+          }
+          throw error;
+        }
+      }
+
       const provider = routerService.getProvider(chainId);
       if (!provider) {
         log.debug(
@@ -245,9 +281,6 @@ export function createLpCreateHandler(
         });
         return;
       }
-
-      const token0Addr = getTokenAddress(position.pool.token0, chainId);
-      const token1Addr = getTokenAddress(position.pool.token1, chainId);
 
       // ============================================
       // Check for Gateway LP routing (JUSD involved)
@@ -543,40 +576,6 @@ async function handleGatewayLpCreate(
   // Get token addresses (user-facing, not converted)
   const token0Addr = getTokenAddress(position.pool.token0, chainId);
   const token1Addr = getTokenAddress(position.pool.token1, chainId);
-
-  const gatewayDepositToken = [token0Addr, token1Addr].find((token) =>
-    [
-      contracts.JUSD,
-      contracts.SUSD,
-      contracts.USDC,
-      contracts.USDT,
-      contracts.CTUSD,
-      contracts.JUICE,
-    ].some((candidate) => candidate?.toLowerCase() === token.toLowerCase()),
-  );
-  if (gatewayDepositToken) {
-    try {
-      await juiceGatewayService.prepareQuote(
-        chainId as ChainId,
-        gatewayDepositToken,
-        contracts.WCBTC,
-        "1",
-      );
-    } catch (error) {
-      if ((error as { code?: string }).code === "GATEWAY_DEPOSIT_DISABLED") {
-        sendGatewayDepositDisabled(res, log, {
-          chainId,
-          token0: token0Addr,
-          token1: token1Addr,
-          savingsRate: (error as { savingsRate?: string }).savingsRate,
-          savingsAddress: (error as { savingsAddress?: string | null })
-            .savingsAddress,
-        });
-        return;
-      }
-      throw error;
-    }
-  }
 
   // Get internal pool tokens (JUSD → svJUSD)
   const internalToken0 = juiceGatewayService.getInternalPoolToken(

--- a/src/endpoints/lpCreate.ts
+++ b/src/endpoints/lpCreate.ts
@@ -218,15 +218,11 @@ export function createLpCreateHandler(
       const token0Addr = getTokenAddress(position.pool.token0, chainId);
       const token1Addr = getTokenAddress(position.pool.token1, chainId);
 
-      if (
-        juiceGatewayService &&
-        hasJuiceDollarIntegration(chainId) &&
-        juiceGatewayService.detectLpGatewayRouting(
-          chainId,
-          token0Addr,
-          token1Addr,
-        )
-      ) {
+      // Deposit gate: must run for any LP route that would deposit into svJUSD
+      // (JUSD or bridged stablecoin or JUICE leg), independent of whether the
+      // route is handled by the Gateway LP path. rejectIfLpRoute... is a no-op
+      // for routes that don't touch a deposit token.
+      if (juiceGatewayService && hasJuiceDollarIntegration(chainId)) {
         try {
           await juiceGatewayService.rejectIfLpRouteRequiresJusdDepositDisabled(
             chainId as ChainId,

--- a/src/endpoints/lpCreate.ts
+++ b/src/endpoints/lpCreate.ts
@@ -21,6 +21,10 @@ import { getPoolInstance } from "../utils/poolFactory";
 import { TICK_SPACING } from "./_shared/v3LpCommon";
 import { JuiceGatewayService } from "../services/JuiceGatewayService";
 import {
+  isGatewayDepositDisabledError,
+  sendGatewayDepositDisabled,
+} from "./gatewayDepositGuard";
+import {
   getChainContracts,
   hasJuiceDollarIntegration,
 } from "../config/contracts";
@@ -53,19 +57,6 @@ const calculateTxValue = (
   const amount = token0 === ADDRESS_ZERO ? amount0Raw : amount1Raw;
   return ethers.BigNumber.from(amount);
 };
-
-function sendGatewayDepositDisabled(
-  res: Response,
-  log: Logger,
-  context: Record<string, unknown>,
-): void {
-  log.warn(context, "Gateway LP deposit disabled");
-  res.status(404).json({
-    error: "GATEWAY_DEPOSIT_DISABLED",
-    detail:
-      "JUSD savings rate is zero; svJUSD deposits revert while Savings is disabled.",
-  });
-}
 
 type IndependentToken = "TOKEN_0" | "TOKEN_1";
 
@@ -243,16 +234,11 @@ export function createLpCreateHandler(
             token1Addr,
           );
         } catch (error) {
-          if (
-            (error as { code?: string }).code === "GATEWAY_DEPOSIT_DISABLED"
-          ) {
-            sendGatewayDepositDisabled(res, log, {
+          if (isGatewayDepositDisabledError(error)) {
+            sendGatewayDepositDisabled(res, log, error, {
               chainId,
               token0: token0Addr,
               token1: token1Addr,
-              savingsRate: (error as { savingsRate?: string }).savingsRate,
-              savingsAddress: (error as { savingsAddress?: string | null })
-                .savingsAddress,
             });
             return;
           }

--- a/src/endpoints/lpIncrease.ts
+++ b/src/endpoints/lpIncrease.ts
@@ -5,6 +5,10 @@ import JSBI from "jsbi";
 import { RouterService } from "../core/RouterService";
 import { JuiceGatewayService } from "../services/JuiceGatewayService";
 import {
+  isGatewayDepositDisabledError,
+  sendGatewayDepositDisabled,
+} from "./gatewayDepositGuard";
+import {
   CurrencyAmount,
   Percent,
   Ether,
@@ -44,18 +48,6 @@ interface LpIncreaseRequestBody {
 const isNativeCurrencyPair = (token0: string, token1: string) =>
   token0 === ADDRESS_ZERO || token1 === ADDRESS_ZERO;
 
-function sendGatewayDepositDisabled(
-  res: Response,
-  log: Logger,
-  context: Record<string, unknown>,
-): void {
-  log.warn(context, "Gateway LP deposit disabled");
-  res.status(404).json({
-    error: "GATEWAY_DEPOSIT_DISABLED",
-    detail:
-      "JUSD savings rate is zero; svJUSD deposits revert while Savings is disabled.",
-  });
-}
 
 /**
  * @swagger
@@ -168,16 +160,11 @@ export function createLpIncreaseHandler(
             userToken1Addr,
           );
         } catch (error) {
-          if (
-            (error as { code?: string }).code === "GATEWAY_DEPOSIT_DISABLED"
-          ) {
-            sendGatewayDepositDisabled(res, log, {
+          if (isGatewayDepositDisabledError(error)) {
+            sendGatewayDepositDisabled(res, log, error, {
               chainId,
               token0: userToken0Addr,
               token1: userToken1Addr,
-              savingsRate: (error as { savingsRate?: string }).savingsRate,
-              savingsAddress: (error as { savingsAddress?: string | null })
-                .savingsAddress,
             });
             return;
           }

--- a/src/endpoints/lpIncrease.ts
+++ b/src/endpoints/lpIncrease.ts
@@ -44,6 +44,19 @@ interface LpIncreaseRequestBody {
 const isNativeCurrencyPair = (token0: string, token1: string) =>
   token0 === ADDRESS_ZERO || token1 === ADDRESS_ZERO;
 
+function sendGatewayDepositDisabled(
+  res: Response,
+  log: Logger,
+  context: Record<string, unknown>,
+): void {
+  log.warn(context, "Gateway LP deposit disabled");
+  res.status(404).json({
+    error: "GATEWAY_DEPOSIT_DISABLED",
+    detail:
+      "JUSD savings rate is zero; svJUSD deposits revert while Savings is disabled.",
+  });
+}
+
 /**
  * @swagger
  * /v1/lp/increase:
@@ -358,6 +371,40 @@ async function handleGatewayLpIncrease(params: {
     userToken0Addr.toLowerCase() === contracts.JUSD.toLowerCase();
   const isToken1Jusd =
     userToken1Addr.toLowerCase() === contracts.JUSD.toLowerCase();
+
+  const gatewayDepositToken = [userToken0Addr, userToken1Addr].find((token) =>
+    [
+      contracts.JUSD,
+      contracts.SUSD,
+      contracts.USDC,
+      contracts.USDT,
+      contracts.CTUSD,
+      contracts.JUICE,
+    ].some((candidate) => candidate?.toLowerCase() === token.toLowerCase()),
+  );
+  if (gatewayDepositToken) {
+    try {
+      await juiceGatewayService.prepareQuote(
+        chainId as ChainId,
+        gatewayDepositToken,
+        contracts.WCBTC,
+        "1",
+      );
+    } catch (error) {
+      if ((error as { code?: string }).code === "GATEWAY_DEPOSIT_DISABLED") {
+        sendGatewayDepositDisabled(res, log, {
+          chainId,
+          token0: userToken0Addr,
+          token1: userToken1Addr,
+          savingsRate: (error as { savingsRate?: string }).savingsRate,
+          savingsAddress: (error as { savingsAddress?: string | null })
+            .savingsAddress,
+        });
+        return;
+      }
+      throw error;
+    }
+  }
 
   // Convert independent amount to svJUSD for position calculation
   let internalIndependentAmount = independentAmount;

--- a/src/endpoints/lpIncrease.ts
+++ b/src/endpoints/lpIncrease.ts
@@ -143,15 +143,11 @@ export function createLpIncreaseHandler(
       const userToken0Addr = getTokenAddress(position.pool.token0, chainId);
       const userToken1Addr = getTokenAddress(position.pool.token1, chainId);
 
-      if (
-        juiceGatewayService &&
-        hasJuiceDollarIntegration(chainId) &&
-        juiceGatewayService.detectLpGatewayRouting(
-          chainId,
-          userToken0Addr,
-          userToken1Addr,
-        )
-      ) {
+      // Deposit gate: must run for any LP route that would deposit into svJUSD
+      // (JUSD or bridged stablecoin or JUICE leg), independent of whether the
+      // route is handled by the Gateway LP path. rejectIfLpRoute... is a no-op
+      // for routes that don't touch a deposit token.
+      if (juiceGatewayService && hasJuiceDollarIntegration(chainId)) {
         try {
           await juiceGatewayService.rejectIfLpRouteRequiresJusdDepositDisabled(
             chainId as ChainId,

--- a/src/endpoints/lpIncrease.ts
+++ b/src/endpoints/lpIncrease.ts
@@ -148,6 +148,43 @@ export function createLpIncreaseHandler(
         return;
       }
 
+      // Get user-facing token addresses (before JUSD→svJUSD mapping)
+      const userToken0Addr = getTokenAddress(position.pool.token0, chainId);
+      const userToken1Addr = getTokenAddress(position.pool.token1, chainId);
+
+      if (
+        juiceGatewayService &&
+        hasJuiceDollarIntegration(chainId) &&
+        juiceGatewayService.detectLpGatewayRouting(
+          chainId,
+          userToken0Addr,
+          userToken1Addr,
+        )
+      ) {
+        try {
+          await juiceGatewayService.rejectIfLpRouteRequiresJusdDepositDisabled(
+            chainId as ChainId,
+            userToken0Addr,
+            userToken1Addr,
+          );
+        } catch (error) {
+          if (
+            (error as { code?: string }).code === "GATEWAY_DEPOSIT_DISABLED"
+          ) {
+            sendGatewayDepositDisabled(res, log, {
+              chainId,
+              token0: userToken0Addr,
+              token1: userToken1Addr,
+              savingsRate: (error as { savingsRate?: string }).savingsRate,
+              savingsAddress: (error as { savingsAddress?: string | null })
+                .savingsAddress,
+            });
+            return;
+          }
+          throw error;
+        }
+      }
+
       const ctx = await getV3LpContext({
         routerService,
         logger: log,
@@ -170,10 +207,6 @@ export function createLpIncreaseHandler(
         tickLower,
         tickUpper,
       } = ctx.data;
-
-      // Get user-facing token addresses (before JUSD→svJUSD mapping)
-      const userToken0Addr = getTokenAddress(position.pool.token0, chainId);
-      const userToken1Addr = getTokenAddress(position.pool.token1, chainId);
 
       // Check for Gateway routing (JUSD involved)
       if (
@@ -371,40 +404,6 @@ async function handleGatewayLpIncrease(params: {
     userToken0Addr.toLowerCase() === contracts.JUSD.toLowerCase();
   const isToken1Jusd =
     userToken1Addr.toLowerCase() === contracts.JUSD.toLowerCase();
-
-  const gatewayDepositToken = [userToken0Addr, userToken1Addr].find((token) =>
-    [
-      contracts.JUSD,
-      contracts.SUSD,
-      contracts.USDC,
-      contracts.USDT,
-      contracts.CTUSD,
-      contracts.JUICE,
-    ].some((candidate) => candidate?.toLowerCase() === token.toLowerCase()),
-  );
-  if (gatewayDepositToken) {
-    try {
-      await juiceGatewayService.prepareQuote(
-        chainId as ChainId,
-        gatewayDepositToken,
-        contracts.WCBTC,
-        "1",
-      );
-    } catch (error) {
-      if ((error as { code?: string }).code === "GATEWAY_DEPOSIT_DISABLED") {
-        sendGatewayDepositDisabled(res, log, {
-          chainId,
-          token0: userToken0Addr,
-          token1: userToken1Addr,
-          savingsRate: (error as { savingsRate?: string }).savingsRate,
-          savingsAddress: (error as { savingsAddress?: string | null })
-            .savingsAddress,
-        });
-        return;
-      }
-      throw error;
-    }
-  }
 
   // Convert independent amount to svJUSD for position calculation
   let internalIndependentAmount = independentAmount;

--- a/src/endpoints/lpIncrease.ts
+++ b/src/endpoints/lpIncrease.ts
@@ -48,7 +48,6 @@ interface LpIncreaseRequestBody {
 const isNativeCurrencyPair = (token0: string, token1: string) =>
   token0 === ADDRESS_ZERO || token1 === ADDRESS_ZERO;
 
-
 /**
  * @swagger
  * /v1/lp/increase:

--- a/src/endpoints/quote.ts
+++ b/src/endpoints/quote.ts
@@ -286,6 +286,90 @@ export function createQuoteHandler(
         return;
       }
 
+      // Native wrap/unwrap quotes are safe to serve from cache; Gateway gating
+      // only applies to non-launchpad JuiceDollar routes.
+      const wrappedAddress = nativeOnChain(chainId).wrapped.address;
+      const isWrapOperation =
+        (isNativeCurrency(tokenIn) &&
+          tokenOut.toLowerCase() === wrappedAddress.toLowerCase()) ||
+        (isNativeCurrency(tokenOut) &&
+          tokenIn.toLowerCase() === wrappedAddress.toLowerCase());
+
+      // ============================================
+      // Check for Launchpad Tokens FIRST
+      // ============================================
+      // Launchpad tokens ALWAYS use V2 pools with JUSD directly (not svJUSD)
+      // They must BYPASS Gateway routing entirely
+      let isGraduatedIn = false;
+      let isGraduatedOut = false;
+      let hasLaunchpadToken = false;
+      if (!isWrapOperation) {
+        [isGraduatedIn, isGraduatedOut] = await Promise.all([
+          isGraduatedLaunchpadToken(chainId, tokenIn),
+          isGraduatedLaunchpadToken(chainId, tokenOut),
+        ]);
+        hasLaunchpadToken = isGraduatedIn || isGraduatedOut;
+
+        if (hasLaunchpadToken) {
+          log.debug(
+            { tokenIn, tokenOut, isGraduatedIn, isGraduatedOut },
+            "Graduated launchpad token detected - bypassing Gateway, using direct V2 routing with JUSD",
+          );
+        }
+      }
+
+      if (
+        !isWrapOperation &&
+        !hasLaunchpadToken &&
+        juiceGatewayService &&
+        hasJuiceDollarIntegration(chainId)
+      ) {
+        const routingType = juiceGatewayService.detectRoutingType(
+          chainId,
+          tokenIn,
+          tokenOut,
+        );
+
+        if (routingType) {
+          try {
+            await juiceGatewayService.rejectIfRouteRequiresJusdDepositDisabled(
+              chainId,
+              tokenIn,
+              tokenOut,
+              routingType,
+            );
+          } catch (error) {
+            const gatewayError = error as {
+              code?: string;
+              message?: string;
+              savingsRate?: string;
+              savingsAddress?: string | null;
+            };
+            if (gatewayError.code === "GATEWAY_DEPOSIT_DISABLED") {
+              log.warn(
+                {
+                  routingType,
+                  tokenIn,
+                  tokenOut,
+                  chainId,
+                  savingsRate: gatewayError.savingsRate,
+                  savingsAddress: gatewayError.savingsAddress,
+                },
+                "Gateway deposit disabled",
+              );
+              res.status(404).json({
+                error: "GATEWAY_DEPOSIT_DISABLED",
+                detail:
+                  gatewayError.message ||
+                  "JUSD savings rate is zero; svJUSD deposits revert while Savings is disabled.",
+              });
+              return;
+            }
+            throw error;
+          }
+        }
+      }
+
       // Fetch token decimals from token lists if not provided (matches develop behavior)
       let tokenInDecimals = body.tokenInDecimals;
       let tokenOutDecimals = body.tokenOutDecimals;
@@ -376,13 +460,6 @@ export function createQuoteHandler(
       rpcMonitor?.startRequest(requestId);
 
       // Handle native <-> wrapped token operations (cBTC <-> WCBTC)
-      const wrappedAddress = nativeOnChain(chainId).wrapped.address;
-      const isWrapOperation =
-        (isNativeCurrency(tokenIn) &&
-          tokenOut.toLowerCase() === wrappedAddress.toLowerCase()) ||
-        (isNativeCurrency(tokenOut) &&
-          tokenIn.toLowerCase() === wrappedAddress.toLowerCase());
-
       if (isWrapOperation) {
         // Return AWS-compatible WRAP response
         const wrapResponse: QuoteResponse = {
@@ -428,24 +505,6 @@ export function createQuoteHandler(
         res.setHeader("X-Response-Time", `${Date.now() - startTime}ms`);
         res.json(wrapResponse);
         return;
-      }
-
-      // ============================================
-      // Check for Launchpad Tokens FIRST
-      // ============================================
-      // Launchpad tokens ALWAYS use V2 pools with JUSD directly (not svJUSD)
-      // They must BYPASS Gateway routing entirely
-      const [isGraduatedIn, isGraduatedOut] = await Promise.all([
-        isGraduatedLaunchpadToken(chainId, tokenIn),
-        isGraduatedLaunchpadToken(chainId, tokenOut),
-      ]);
-      const hasLaunchpadToken = isGraduatedIn || isGraduatedOut;
-
-      if (hasLaunchpadToken) {
-        log.debug(
-          { tokenIn, tokenOut, isGraduatedIn, isGraduatedOut },
-          "Graduated launchpad token detected - bypassing Gateway, using direct V2 routing with JUSD",
-        );
       }
 
       // ============================================

--- a/src/endpoints/quote.ts
+++ b/src/endpoints/quote.ts
@@ -714,6 +714,33 @@ export function createQuoteHandler(
             res.json(gatewayResponse);
             return;
           } catch (error) {
+            const gatewayError = error as {
+              code?: string;
+              message?: string;
+              savingsRate?: string;
+              savingsAddress?: string | null;
+            };
+            if (gatewayError.code === "GATEWAY_DEPOSIT_DISABLED") {
+              log.warn(
+                {
+                  routingType,
+                  tokenIn,
+                  tokenOut,
+                  chainId,
+                  savingsRate: gatewayError.savingsRate,
+                  savingsAddress: gatewayError.savingsAddress,
+                },
+                "Gateway deposit disabled",
+              );
+              res.status(404).json({
+                error: "GATEWAY_DEPOSIT_DISABLED",
+                detail:
+                  gatewayError.message ||
+                  "JUSD savings rate is zero; svJUSD deposits revert while Savings is disabled.",
+              });
+              return;
+            }
+
             // Bridge liquidity error - fall through to classic V3 routing
             // This allows direct pools (e.g., ctUSD/USDC.e) to be used when bridge is empty
             if (error instanceof BridgeLiquidityError) {

--- a/src/endpoints/quote.ts
+++ b/src/endpoints/quote.ts
@@ -18,6 +18,10 @@ import {
   hasJuiceDollarIntegration,
 } from "../config/contracts";
 import { isGraduatedLaunchpadToken } from "../services/LaunchpadTokenService";
+import {
+  isGatewayDepositDisabledError,
+  sendGatewayDepositDisabled,
+} from "./gatewayDepositGuard";
 import Logger from "bunyan";
 
 // Helper functions for AWS-compatible response formatting
@@ -339,29 +343,12 @@ export function createQuoteHandler(
               routingType,
             );
           } catch (error) {
-            const gatewayError = error as {
-              code?: string;
-              message?: string;
-              savingsRate?: string;
-              savingsAddress?: string | null;
-            };
-            if (gatewayError.code === "GATEWAY_DEPOSIT_DISABLED") {
-              log.warn(
-                {
-                  routingType,
-                  tokenIn,
-                  tokenOut,
-                  chainId,
-                  savingsRate: gatewayError.savingsRate,
-                  savingsAddress: gatewayError.savingsAddress,
-                },
-                "Gateway deposit disabled",
-              );
-              res.status(404).json({
-                error: "GATEWAY_DEPOSIT_DISABLED",
-                detail:
-                  gatewayError.message ||
-                  "JUSD savings rate is zero; svJUSD deposits revert while Savings is disabled.",
+            if (isGatewayDepositDisabledError(error)) {
+              sendGatewayDepositDisabled(res, log, error, {
+                routingType,
+                tokenIn,
+                tokenOut,
+                chainId,
               });
               return;
             }
@@ -773,29 +760,12 @@ export function createQuoteHandler(
             res.json(gatewayResponse);
             return;
           } catch (error) {
-            const gatewayError = error as {
-              code?: string;
-              message?: string;
-              savingsRate?: string;
-              savingsAddress?: string | null;
-            };
-            if (gatewayError.code === "GATEWAY_DEPOSIT_DISABLED") {
-              log.warn(
-                {
-                  routingType,
-                  tokenIn,
-                  tokenOut,
-                  chainId,
-                  savingsRate: gatewayError.savingsRate,
-                  savingsAddress: gatewayError.savingsAddress,
-                },
-                "Gateway deposit disabled",
-              );
-              res.status(404).json({
-                error: "GATEWAY_DEPOSIT_DISABLED",
-                detail:
-                  gatewayError.message ||
-                  "JUSD savings rate is zero; svJUSD deposits revert while Savings is disabled.",
+            if (isGatewayDepositDisabledError(error)) {
+              sendGatewayDepositDisabled(res, log, error, {
+                routingType,
+                tokenIn,
+                tokenOut,
+                chainId,
               });
               return;
             }

--- a/src/endpoints/swap.ts
+++ b/src/endpoints/swap.ts
@@ -757,6 +757,36 @@ async function handleGatewaySwap(
       ],
     });
   } catch (error) {
+    const gatewayError = error as {
+      code?: string;
+      message?: string;
+      savingsRate?: string;
+      savingsAddress?: string | null;
+    };
+    if (gatewayError.code === "GATEWAY_DEPOSIT_DISABLED") {
+      const tokenIn = body.tokenIn || body.tokenInAddress!;
+      const tokenOut = body.tokenOut || body.tokenOutAddress!;
+      const chainId = (body.chainId || body.tokenInChainId) as ChainId;
+      log.warn(
+        {
+          routingType,
+          tokenIn,
+          tokenOut,
+          chainId,
+          savingsRate: gatewayError.savingsRate,
+          savingsAddress: gatewayError.savingsAddress,
+        },
+        "Gateway deposit disabled",
+      );
+      res.status(404).json({
+        error: "GATEWAY_DEPOSIT_DISABLED",
+        detail:
+          gatewayError.message ||
+          "JUSD savings rate is zero; svJUSD deposits revert while Savings is disabled.",
+      });
+      return;
+    }
+
     // Bridge liquidity error - fall through to classic V3 routing
     // This allows direct pools (e.g., ctUSD/USDC.e) to be used when bridge is empty
     if (error instanceof BridgeLiquidityError) {

--- a/src/endpoints/swap.ts
+++ b/src/endpoints/swap.ts
@@ -17,6 +17,10 @@ import { isGraduatedLaunchpadToken } from "../services/LaunchpadTokenService";
 import { ethers } from "ethers";
 import Logger from "bunyan";
 import { Routing } from "./quote";
+import {
+  isGatewayDepositDisabledError,
+  sendGatewayDepositDisabled,
+} from "./gatewayDepositGuard";
 
 const BASIS_POINTS_DENOMINATOR = 10000;
 
@@ -764,32 +768,12 @@ async function handleGatewaySwap(
       ],
     });
   } catch (error) {
-    const gatewayError = error as {
-      code?: string;
-      message?: string;
-      savingsRate?: string;
-      savingsAddress?: string | null;
-    };
-    if (gatewayError.code === "GATEWAY_DEPOSIT_DISABLED") {
-      const tokenIn = body.tokenIn || body.tokenInAddress!;
-      const tokenOut = body.tokenOut || body.tokenOutAddress!;
-      const chainId = (body.chainId || body.tokenInChainId) as ChainId;
-      log.warn(
-        {
-          routingType,
-          tokenIn,
-          tokenOut,
-          chainId,
-          savingsRate: gatewayError.savingsRate,
-          savingsAddress: gatewayError.savingsAddress,
-        },
-        "Gateway deposit disabled",
-      );
-      res.status(404).json({
-        error: "GATEWAY_DEPOSIT_DISABLED",
-        detail:
-          gatewayError.message ||
-          "JUSD savings rate is zero; svJUSD deposits revert while Savings is disabled.",
+    if (isGatewayDepositDisabledError(error)) {
+      sendGatewayDepositDisabled(res, log, error, {
+        routingType,
+        tokenIn: body.tokenIn || body.tokenInAddress,
+        tokenOut: body.tokenOut || body.tokenOutAddress,
+        chainId: body.chainId || body.tokenInChainId,
       });
       return;
     }

--- a/src/endpoints/swap.ts
+++ b/src/endpoints/swap.ts
@@ -440,6 +440,13 @@ async function handleGatewaySwap(
       return;
     }
 
+    await juiceGatewayService.rejectIfRouteRequiresJusdDepositDisabled(
+      chainId,
+      tokenIn,
+      tokenOut,
+      routingType,
+    );
+
     // Get RPC provider for gas prices
     const provider = routerService.getProvider(chainId);
     if (!provider) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -340,7 +340,12 @@ async function bootstrap() {
     logger,
     svJusdPriceService,
   );
-  initializeResolvers(routerService, logger, exploreStatsService);
+  initializeResolvers(
+    routerService,
+    logger,
+    exploreStatsService,
+    juiceGatewayService,
+  );
   const handlePoolDetails = createPoolDetailsHandler(
     providers,
     logger,

--- a/src/server.ts
+++ b/src/server.ts
@@ -780,6 +780,7 @@ async function bootstrap() {
       trackedUsers,
       uniqueIps: uniqueIpResult.length,
       quoteCache: quoteCache.getStats(),
+      gateway: juiceGatewayService.getMetrics(),
     });
   });
 

--- a/src/services/JuiceGatewayService.ts
+++ b/src/services/JuiceGatewayService.ts
@@ -141,6 +141,7 @@ export class JuiceGatewayService {
   private gatewayContracts: Map<ChainId, ethers.Contract> = new Map();
   private equityContracts: Map<ChainId, ethers.Contract> = new Map();
   private savingsRateProbe: SavingsRateProbe;
+  private blockedDeposits: Map<string, number> = new Map();
 
   constructor(
     providers: Map<ChainId, ethers.providers.StaticJsonRpcProvider>,
@@ -203,13 +204,23 @@ export class JuiceGatewayService {
     );
   }
 
-  private async rejectIfJusdDepositDisabled(chainId: ChainId): Promise<void> {
+  private async rejectIfJusdDepositDisabled(
+    chainId: ChainId,
+    routeShape: string,
+  ): Promise<void> {
     const savings = await this.getSavingsRate(chainId);
     if (!savings.rate.isZero()) return;
+
+    const counterKey = `${chainId}:${routeShape}`;
+    this.blockedDeposits.set(
+      counterKey,
+      (this.blockedDeposits.get(counterKey) ?? 0) + 1,
+    );
 
     this.logger.warn(
       {
         chainId,
+        routeShape,
         savingsRate: savings.rate.toString(),
         savingsAddress: savings.address,
       },
@@ -220,6 +231,22 @@ export class JuiceGatewayService {
       savings.rate.toString(),
       savings.address,
     );
+  }
+
+  /**
+   * Telemetry snapshot for the /metrics endpoint:
+   * - blockedDeposits: count of deposit-route rejections keyed by
+   *   `<chainId>:<routeShape>` (route shape = routing type, or "LP").
+   * - savingsRate: the SavingsRateProbe gauge/failure counters.
+   */
+  getMetrics(): {
+    blockedDeposits: Record<string, number>;
+    savingsRate: ReturnType<SavingsRateProbe["getMetrics"]>;
+  } {
+    return {
+      blockedDeposits: Object.fromEntries(this.blockedDeposits),
+      savingsRate: this.savingsRateProbe.getMetrics(),
+    };
   }
 
   private routeRequiresJusdDeposit(
@@ -263,7 +290,7 @@ export class JuiceGatewayService {
     if (
       this.routeRequiresJusdDeposit(chainId, tokenIn, tokenOut, routingType)
     ) {
-      await this.rejectIfJusdDepositDisabled(chainId);
+      await this.rejectIfJusdDepositDisabled(chainId, routingType);
     }
   }
 
@@ -281,7 +308,7 @@ export class JuiceGatewayService {
       isJuiceAddress(chainId, tokenB);
 
     if (requiresDeposit) {
-      await this.rejectIfJusdDepositDisabled(chainId);
+      await this.rejectIfJusdDepositDisabled(chainId, "LP");
     }
   }
 

--- a/src/services/JuiceGatewayService.ts
+++ b/src/services/JuiceGatewayService.ts
@@ -1023,7 +1023,16 @@ export class JuiceGatewayService {
   // ============================================
 
   /**
-   * Check if LP operation involves JUSD and should route through Gateway
+   * Check if LP operation involves JUSD and should route through Gateway.
+   *
+   * NOTE: this is intentionally JUSD-only. It is the trigger for the Gateway LP
+   * handlers (handleGatewayLpCreate/handleGatewayLpIncrease), whose amount
+   * conversion only knows how to convert literal JUSD ↔ svJUSD. Do not widen it
+   * to bridged stablecoins / JUICE without also teaching those handlers the
+   * corresponding conversions, or non-JUSD legs are fed unconverted into the
+   * svJUSD position math. The deposit gate uses its own predicate
+   * (rejectIfLpRouteRequiresJusdDepositDisabled), so it does not depend on this.
+   *
    * @returns true if either token is JUSD (requires Gateway for JUSD → svJUSD conversion)
    */
   detectLpGatewayRouting(
@@ -1034,14 +1043,7 @@ export class JuiceGatewayService {
     if (!hasJuiceDollarIntegration(chainId)) {
       return false;
     }
-    return (
-      isJusdAddress(chainId, tokenA) ||
-      isJusdAddress(chainId, tokenB) ||
-      isBridgedStablecoin(chainId, tokenA) ||
-      isBridgedStablecoin(chainId, tokenB) ||
-      isJuiceAddress(chainId, tokenA) ||
-      isJuiceAddress(chainId, tokenB)
-    );
+    return isJusdAddress(chainId, tokenA) || isJusdAddress(chainId, tokenB);
   }
 
   /**
@@ -1108,17 +1110,18 @@ export class JuiceGatewayService {
 
   /**
    * Convert token address to internal pool token
-   * JUSD/bridged stablecoin/JUICE → svJUSD for LP operations
+   * JUSD → svJUSD for LP operations.
+   *
+   * NOTE: JUSD-only on purpose — pairs with detectLpGatewayRouting. The LP
+   * handlers only convert amounts for literal JUSD legs, so mapping bridged
+   * stablecoins / JUICE here would route them into the svJUSD pool with raw,
+   * unconverted amounts.
    */
   getInternalPoolToken(chainId: number, token: string): string {
     const contracts = getChainContracts(chainId);
     if (!contracts) return token;
 
-    if (
-      isJusdAddress(chainId, token) ||
-      isBridgedStablecoin(chainId, token) ||
-      isJuiceAddress(chainId, token)
-    ) {
+    if (isJusdAddress(chainId, token)) {
       return contracts.SV_JUSD;
     }
     return token;

--- a/src/services/JuiceGatewayService.ts
+++ b/src/services/JuiceGatewayService.ts
@@ -12,6 +12,7 @@ import {
   ChainContracts,
 } from "../config/contracts";
 import { JuiceSwapGatewayAbi } from "../abi/JuiceSwapGateway";
+import { SavingsRateProbe } from "./SavingsRateProbe";
 
 /**
  * ABI fragments for JUICE Equity contract
@@ -22,14 +23,6 @@ const EQUITY_ABI = [
   "function calculateProceeds(uint256 shares) view returns (uint256)",
   "function calculateShares(uint256 investment) view returns (uint256)",
 ];
-
-const SAVINGS_VAULT_ABI = [
-  "function SAVINGS() view returns (address)",
-];
-const SAVINGS_ABI = [
-  "function currentRatePPM() view returns (uint24)",
-];
-const SAVINGS_RATE_CACHE_TTL_MS = 15_000;
 
 class GatewayDepositDisabledError extends Error {
   code = "GATEWAY_DEPOSIT_DISABLED";
@@ -147,17 +140,16 @@ export class JuiceGatewayService {
   private logger: Logger;
   private gatewayContracts: Map<ChainId, ethers.Contract> = new Map();
   private equityContracts: Map<ChainId, ethers.Contract> = new Map();
-  private savingsVaultContracts: Map<ChainId, ethers.Contract> = new Map();
-  private savingsRateCache: Map<
-    ChainId,
-    { rate: ethers.BigNumber; fetchedAt: number; address: string | null }
-  > = new Map();
+  private savingsRateProbe: SavingsRateProbe;
 
   constructor(
     providers: Map<ChainId, ethers.providers.StaticJsonRpcProvider>,
     logger: Logger,
+    savingsRateProbe?: SavingsRateProbe,
   ) {
     this.logger = logger.child({ service: "JuiceGatewayService" });
+    this.savingsRateProbe =
+      savingsRateProbe ?? new SavingsRateProbe(this.logger);
 
     // Initialize contracts for chains with JuiceDollar integration
     for (const [chainId, provider] of providers) {
@@ -185,52 +177,30 @@ export class JuiceGatewayService {
       chainId,
       new ethers.Contract(contracts.JUICE, EQUITY_ABI, provider),
     );
-    this.savingsVaultContracts.set(
-      chainId,
-      new ethers.Contract(contracts.SV_JUSD, SAVINGS_VAULT_ABI, provider),
-    );
+    this.savingsRateProbe.registerVault(chainId, contracts.SV_JUSD, provider);
     this.logger.info({ chainId }, "JuiceDollar contracts initialized");
+  }
+
+  setSavingsRateOverride(
+    chainId: ChainId,
+    rate: ethers.BigNumberish,
+    savingsAddress: string | null = null,
+  ): void {
+    this.savingsRateProbe.setOverride(chainId, rate, savingsAddress);
+  }
+
+  clearSavingsRateOverride(chainId?: ChainId): void {
+    this.savingsRateProbe.clearOverride(chainId);
   }
 
   private async getSavingsRate(chainId: ChainId): Promise<{
     rate: ethers.BigNumber;
     address: string | null;
   }> {
-    const cached = this.savingsRateCache.get(chainId);
-    if (cached && Date.now() - cached.fetchedAt < SAVINGS_RATE_CACHE_TTL_MS) {
-      return { rate: cached.rate, address: cached.address };
-    }
-
-    const vaultAddress = this.getSvJusdAddress(chainId);
-    const vaultContract = this.savingsVaultContracts.get(chainId);
-    if (!vaultContract || !vaultContract.provider) {
-      return { rate: ethers.constants.One, address: null };
-    }
-
-    let savingsAddress: string | null = null;
-    let rate: ethers.BigNumber = ethers.constants.One;
-    try {
-      const probedSavingsAddress = await vaultContract.SAVINGS();
-      savingsAddress = probedSavingsAddress;
-      const savingsContract = new ethers.Contract(
-        probedSavingsAddress,
-        SAVINGS_ABI,
-        vaultContract.provider,
-      );
-      rate = ethers.BigNumber.from(await savingsContract.currentRatePPM());
-    } catch (error) {
-      this.logger.warn(
-        { chainId, savingsVaultAddress: vaultAddress, savingsAddress, error },
-        "Savings currentRatePPM probe failed; allowing Gateway route",
-      );
-    }
-
-    this.savingsRateCache.set(chainId, {
-      rate,
-      fetchedAt: Date.now(),
-      address: savingsAddress,
-    });
-    return { rate, address: savingsAddress };
+    return this.savingsRateProbe.getCurrentRate(
+      chainId,
+      this.getSvJusdAddress(chainId),
+    );
   }
 
   private async rejectIfJusdDepositDisabled(chainId: ChainId): Promise<void> {
@@ -260,9 +230,12 @@ export class JuiceGatewayService {
   ): boolean {
     if (isSvJusdAddress(chainId, tokenIn)) return false;
 
-    const isUsdOut = isUsdToken(chainId, tokenOut);
-    const isJuiceIn = isJuiceAddress(chainId, tokenIn);
     const isJuiceOut = isJuiceAddress(chainId, tokenOut);
+    const isDirectUsdOrJuiceOut =
+      isJusdAddress(chainId, tokenOut) ||
+      isBridgedStablecoin(chainId, tokenOut) ||
+      isJuiceOut;
+    const isJuiceIn = isJuiceAddress(chainId, tokenIn);
     const isJusdIn = isJusdAddress(chainId, tokenIn);
     const isBridgedIn = isBridgedStablecoin(chainId, tokenIn);
 
@@ -274,11 +247,42 @@ export class JuiceGatewayService {
       return false;
     }
 
-    if ((isJusdIn || isBridgedIn) && !isUsdOut && !isJuiceOut) {
+    if ((isJusdIn || isBridgedIn) && !isDirectUsdOrJuiceOut) {
       return true;
     }
 
     return false;
+  }
+
+  async rejectIfRouteRequiresJusdDepositDisabled(
+    chainId: ChainId,
+    tokenIn: string,
+    tokenOut: string,
+    routingType: "GATEWAY_JUSD" | "GATEWAY_JUICE_OUT" | "GATEWAY_JUICE_IN",
+  ): Promise<void> {
+    if (
+      this.routeRequiresJusdDeposit(chainId, tokenIn, tokenOut, routingType)
+    ) {
+      await this.rejectIfJusdDepositDisabled(chainId);
+    }
+  }
+
+  async rejectIfLpRouteRequiresJusdDepositDisabled(
+    chainId: ChainId,
+    tokenA: string,
+    tokenB: string,
+  ): Promise<void> {
+    const requiresDeposit =
+      isJusdAddress(chainId, tokenA) ||
+      isJusdAddress(chainId, tokenB) ||
+      isBridgedStablecoin(chainId, tokenA) ||
+      isBridgedStablecoin(chainId, tokenB) ||
+      isJuiceAddress(chainId, tokenA) ||
+      isJuiceAddress(chainId, tokenB);
+
+    if (requiresDeposit) {
+      await this.rejectIfJusdDepositDisabled(chainId);
+    }
   }
 
   /**
@@ -685,9 +689,12 @@ export class JuiceGatewayService {
     const contracts = getChainContracts(chainId);
     if (!contracts) return null;
 
-    if (this.routeRequiresJusdDeposit(chainId, tokenIn, tokenOut, routingType)) {
-      await this.rejectIfJusdDepositDisabled(chainId);
-    }
+    await this.rejectIfRouteRequiresJusdDepositDisabled(
+      chainId,
+      tokenIn,
+      tokenOut,
+      routingType,
+    );
 
     let internalTokenIn = tokenIn;
     let internalTokenOut = tokenOut;

--- a/src/services/JuiceGatewayService.ts
+++ b/src/services/JuiceGatewayService.ts
@@ -23,6 +23,33 @@ const EQUITY_ABI = [
   "function calculateShares(uint256 investment) view returns (uint256)",
 ];
 
+const SAVINGS_VAULT_ABI = [
+  "function SAVINGS() view returns (address)",
+];
+const SAVINGS_ABI = [
+  "function currentRatePPM() view returns (uint24)",
+];
+const SAVINGS_RATE_CACHE_TTL_MS = 15_000;
+
+class GatewayDepositDisabledError extends Error {
+  code = "GATEWAY_DEPOSIT_DISABLED";
+  chainId: ChainId;
+  savingsRate: string;
+  savingsAddress: string | null;
+
+  constructor(
+    chainId: ChainId,
+    savingsRate: string,
+    savingsAddress: string | null,
+  ) {
+    super("JUSD savings rate is zero; svJUSD deposits are disabled");
+    this.name = "GatewayDepositDisabledError";
+    this.chainId = chainId;
+    this.savingsRate = savingsRate;
+    this.savingsAddress = savingsAddress;
+  }
+}
+
 export interface GatewayQuoteResult {
   internalTokenIn: string;
   internalTokenOut: string;
@@ -120,6 +147,11 @@ export class JuiceGatewayService {
   private logger: Logger;
   private gatewayContracts: Map<ChainId, ethers.Contract> = new Map();
   private equityContracts: Map<ChainId, ethers.Contract> = new Map();
+  private savingsVaultContracts: Map<ChainId, ethers.Contract> = new Map();
+  private savingsRateCache: Map<
+    ChainId,
+    { rate: ethers.BigNumber; fetchedAt: number; address: string | null }
+  > = new Map();
 
   constructor(
     providers: Map<ChainId, ethers.providers.StaticJsonRpcProvider>,
@@ -153,7 +185,100 @@ export class JuiceGatewayService {
       chainId,
       new ethers.Contract(contracts.JUICE, EQUITY_ABI, provider),
     );
+    this.savingsVaultContracts.set(
+      chainId,
+      new ethers.Contract(contracts.SV_JUSD, SAVINGS_VAULT_ABI, provider),
+    );
     this.logger.info({ chainId }, "JuiceDollar contracts initialized");
+  }
+
+  private async getSavingsRate(chainId: ChainId): Promise<{
+    rate: ethers.BigNumber;
+    address: string | null;
+  }> {
+    const cached = this.savingsRateCache.get(chainId);
+    if (cached && Date.now() - cached.fetchedAt < SAVINGS_RATE_CACHE_TTL_MS) {
+      return { rate: cached.rate, address: cached.address };
+    }
+
+    const vaultAddress = this.getSvJusdAddress(chainId);
+    const vaultContract = this.savingsVaultContracts.get(chainId);
+    if (!vaultContract || !vaultContract.provider) {
+      return { rate: ethers.constants.One, address: null };
+    }
+
+    let savingsAddress: string | null = null;
+    let rate: ethers.BigNumber = ethers.constants.One;
+    try {
+      const probedSavingsAddress = await vaultContract.SAVINGS();
+      savingsAddress = probedSavingsAddress;
+      const savingsContract = new ethers.Contract(
+        probedSavingsAddress,
+        SAVINGS_ABI,
+        vaultContract.provider,
+      );
+      rate = ethers.BigNumber.from(await savingsContract.currentRatePPM());
+    } catch (error) {
+      this.logger.warn(
+        { chainId, savingsVaultAddress: vaultAddress, savingsAddress, error },
+        "Savings currentRatePPM probe failed; allowing Gateway route",
+      );
+    }
+
+    this.savingsRateCache.set(chainId, {
+      rate,
+      fetchedAt: Date.now(),
+      address: savingsAddress,
+    });
+    return { rate, address: savingsAddress };
+  }
+
+  private async rejectIfJusdDepositDisabled(chainId: ChainId): Promise<void> {
+    const savings = await this.getSavingsRate(chainId);
+    if (!savings.rate.isZero()) return;
+
+    this.logger.warn(
+      {
+        chainId,
+        savingsRate: savings.rate.toString(),
+        savingsAddress: savings.address,
+      },
+      "Gateway JUSD deposit blocked because Savings rate is zero",
+    );
+    throw new GatewayDepositDisabledError(
+      chainId,
+      savings.rate.toString(),
+      savings.address,
+    );
+  }
+
+  private routeRequiresJusdDeposit(
+    chainId: ChainId,
+    tokenIn: string,
+    tokenOut: string,
+    routingType: "GATEWAY_JUSD" | "GATEWAY_JUICE_OUT" | "GATEWAY_JUICE_IN",
+  ): boolean {
+    if (isSvJusdAddress(chainId, tokenIn)) return false;
+
+    const isUsdOut = isUsdToken(chainId, tokenOut);
+    const isJuiceIn = isJuiceAddress(chainId, tokenIn);
+    const isJuiceOut = isJuiceAddress(chainId, tokenOut);
+    const isJusdIn = isJusdAddress(chainId, tokenIn);
+    const isBridgedIn = isBridgedStablecoin(chainId, tokenIn);
+
+    if (routingType === "GATEWAY_JUICE_IN") {
+      return isJuiceIn && !isJusdAddress(chainId, tokenOut);
+    }
+
+    if (routingType === "GATEWAY_JUICE_OUT") {
+      return false;
+    }
+
+    if ((isJusdIn || isBridgedIn) && !isUsdOut && !isJuiceOut) {
+      return true;
+    }
+
+    return false;
   }
 
   /**
@@ -560,6 +685,10 @@ export class JuiceGatewayService {
     const contracts = getChainContracts(chainId);
     if (!contracts) return null;
 
+    if (this.routeRequiresJusdDeposit(chainId, tokenIn, tokenOut, routingType)) {
+      await this.rejectIfJusdDepositDisabled(chainId);
+    }
+
     let internalTokenIn = tokenIn;
     let internalTokenOut = tokenOut;
     let internalAmountIn = amountIn;
@@ -769,7 +898,8 @@ export class JuiceGatewayService {
       case "GATEWAY_JUICE_IN": {
         // JUICE can only be swapped directly to JUSD
         // Multi-hop swaps (JUICE → X where X is not JUSD) are not supported
-        // Users must manually redeem JUICE for JUSD first, then swap JUSD → X
+        // when Savings deposits are enabled. When disabled, the guard above
+        // returns a structured error instead of calldata that will revert.
         if (!isJusdAddress(chainId, tokenOut)) {
           return null; // Signal unsupported - will fall through to NO_ROUTE
         }
@@ -870,7 +1000,14 @@ export class JuiceGatewayService {
     if (!hasJuiceDollarIntegration(chainId)) {
       return false;
     }
-    return isJusdAddress(chainId, tokenA) || isJusdAddress(chainId, tokenB);
+    return (
+      isJusdAddress(chainId, tokenA) ||
+      isJusdAddress(chainId, tokenB) ||
+      isBridgedStablecoin(chainId, tokenA) ||
+      isBridgedStablecoin(chainId, tokenB) ||
+      isJuiceAddress(chainId, tokenA) ||
+      isJuiceAddress(chainId, tokenB)
+    );
   }
 
   /**
@@ -937,13 +1074,17 @@ export class JuiceGatewayService {
 
   /**
    * Convert token address to internal pool token
-   * JUSD → svJUSD for LP operations
+   * JUSD/bridged stablecoin/JUICE → svJUSD for LP operations
    */
   getInternalPoolToken(chainId: number, token: string): string {
     const contracts = getChainContracts(chainId);
     if (!contracts) return token;
 
-    if (isJusdAddress(chainId, token)) {
+    if (
+      isJusdAddress(chainId, token) ||
+      isBridgedStablecoin(chainId, token) ||
+      isJuiceAddress(chainId, token)
+    ) {
       return contracts.SV_JUSD;
     }
     return token;

--- a/src/services/SavingsRateProbe.ts
+++ b/src/services/SavingsRateProbe.ts
@@ -43,7 +43,7 @@ export class SavingsRateProbe {
     ChainId,
     { rate: ethers.BigNumber; address: string | null }
   > = new Map();
-  private inFlight: Map<ChainId, Promise<void>> = new Map();
+  private inFlight: Map<ChainId, Promise<SavingsRateProbeResult>> = new Map();
   private probeFailures = 0;
   private ratePpmByChain: Map<ChainId, number> = new Map();
 
@@ -79,10 +79,17 @@ export class SavingsRateProbe {
 
   clearOverride(chainId?: ChainId): void {
     if (chainId === undefined) {
+      // Drop the override-seeded gauge values too so /metrics never reports a
+      // stale forced rate after the override is lifted.
+      for (const overriddenChain of this.overrides.keys()) {
+        this.ratePpmByChain.delete(overriddenChain);
+      }
       this.overrides.clear();
       return;
     }
-    this.overrides.delete(chainId);
+    if (this.overrides.delete(chainId)) {
+      this.ratePpmByChain.delete(chainId);
+    }
   }
 
   /**
@@ -103,7 +110,11 @@ export class SavingsRateProbe {
    * Used by tests and for graceful diagnostics; production callers never await it.
    */
   async idle(): Promise<void> {
-    await Promise.all(Array.from(this.inFlight.values()));
+    await Promise.all(
+      Array.from(this.inFlight.values()).map((task) =>
+        task.catch(() => undefined),
+      ),
+    );
   }
 
   async getCurrentRate(
@@ -137,27 +148,39 @@ export class SavingsRateProbe {
     if (cached) {
       // Stale-while-revalidate: hand back the stale rate immediately and
       // refresh in the background so request latency never pays for the probe.
-      this.scheduleRefresh(chainId, vaultContract, savingsVaultAddress);
+      void this.getOrStartRefresh(
+        chainId,
+        vaultContract,
+        savingsVaultAddress,
+      ).catch(() => undefined);
       return { rate: cached.rate, address: cached.address };
     }
 
-    // Cold cache: block on the first probe so the caller gets a real answer.
-    return this.refresh(chainId, vaultContract, savingsVaultAddress);
+    // Cold cache: coalesce concurrent first-callers onto one shared probe so
+    // a burst of startup requests can't stampede the RPC (thundering herd).
+    return this.getOrStartRefresh(
+      chainId,
+      vaultContract,
+      savingsVaultAddress,
+    );
   }
 
-  private scheduleRefresh(
+  private getOrStartRefresh(
     chainId: ChainId,
     vaultContract: ethers.Contract,
     savingsVaultAddress: string | null,
-  ): void {
-    if (this.inFlight.has(chainId)) return;
-    const task = this.refresh(chainId, vaultContract, savingsVaultAddress)
-      .then(() => undefined)
-      .catch(() => undefined)
-      .finally(() => {
-        this.inFlight.delete(chainId);
-      });
+  ): Promise<SavingsRateProbeResult> {
+    const existing = this.inFlight.get(chainId);
+    if (existing) return existing;
+    const task = this.refresh(
+      chainId,
+      vaultContract,
+      savingsVaultAddress,
+    ).finally(() => {
+      this.inFlight.delete(chainId);
+    });
     this.inFlight.set(chainId, task);
+    return task;
   }
 
   private async refresh(

--- a/src/services/SavingsRateProbe.ts
+++ b/src/services/SavingsRateProbe.ts
@@ -220,6 +220,13 @@ export class SavingsRateProbe {
       return { rate: ethers.constants.Zero, address: savingsAddress };
     }
 
+    // A probe that resolves after setOverride() must not resurrect the
+    // pre-override rate into the cache/gauge: the override is authoritative,
+    // and a stale cache entry could otherwise be served after clearOverride().
+    if (this.overrides.has(chainId)) {
+      return { rate, address: savingsAddress };
+    }
+
     this.cache.set(chainId, {
       rate,
       fetchedAt: Date.now(),

--- a/src/services/SavingsRateProbe.ts
+++ b/src/services/SavingsRateProbe.ts
@@ -158,11 +158,7 @@ export class SavingsRateProbe {
 
     // Cold cache: coalesce concurrent first-callers onto one shared probe so
     // a burst of startup requests can't stampede the RPC (thundering herd).
-    return this.getOrStartRefresh(
-      chainId,
-      vaultContract,
-      savingsVaultAddress,
-    );
+    return this.getOrStartRefresh(chainId, vaultContract, savingsVaultAddress);
   }
 
   private getOrStartRefresh(

--- a/src/services/SavingsRateProbe.ts
+++ b/src/services/SavingsRateProbe.ts
@@ -1,0 +1,138 @@
+import { ethers } from "ethers";
+import { ChainId } from "@juiceswapxyz/sdk-core";
+import Logger from "bunyan";
+
+const SAVINGS_VAULT_ABI = ["function SAVINGS() view returns (address)"];
+const SAVINGS_ABI = ["function currentRatePPM() view returns (uint24)"];
+const DEFAULT_SAVINGS_RATE_CACHE_TTL_MS = 60_000;
+
+export interface SavingsRateProbeResult {
+  rate: ethers.BigNumber;
+  address: string | null;
+}
+
+export type SavingsRateContractFactory = (
+  address: string,
+  abi: string[],
+  provider: ethers.providers.Provider,
+) => ethers.Contract;
+
+interface SavingsRateProbeOptions {
+  ttlMs?: number;
+  contractFactory?: SavingsRateContractFactory;
+}
+
+export class SavingsRateProbe {
+  private logger: Logger;
+  private ttlMs: number;
+  private contractFactory: SavingsRateContractFactory;
+  private vaultContracts: Map<ChainId, ethers.Contract> = new Map();
+  private cache: Map<
+    ChainId,
+    { rate: ethers.BigNumber; fetchedAt: number; address: string | null }
+  > = new Map();
+  private overrides: Map<
+    ChainId,
+    { rate: ethers.BigNumber; address: string | null }
+  > = new Map();
+
+  constructor(logger: Logger, options: SavingsRateProbeOptions = {}) {
+    this.logger = logger.child({ service: "SavingsRateProbe" });
+    this.ttlMs = options.ttlMs ?? DEFAULT_SAVINGS_RATE_CACHE_TTL_MS;
+    this.contractFactory =
+      options.contractFactory ??
+      ((address, abi, provider) => new ethers.Contract(address, abi, provider));
+  }
+
+  registerVault(
+    chainId: ChainId,
+    vaultAddress: string,
+    provider: ethers.providers.Provider,
+  ): void {
+    this.vaultContracts.set(
+      chainId,
+      this.contractFactory(vaultAddress, SAVINGS_VAULT_ABI, provider),
+    );
+  }
+
+  setOverride(
+    chainId: ChainId,
+    rate: ethers.BigNumberish,
+    address: string | null = null,
+  ): void {
+    this.overrides.set(chainId, {
+      rate: ethers.BigNumber.from(rate),
+      address,
+    });
+    this.cache.delete(chainId);
+  }
+
+  clearOverride(chainId?: ChainId): void {
+    if (chainId === undefined) {
+      this.overrides.clear();
+      return;
+    }
+    this.overrides.delete(chainId);
+  }
+
+  async getCurrentRate(
+    chainId: ChainId,
+    savingsVaultAddress: string | null,
+  ): Promise<SavingsRateProbeResult> {
+    const override = this.overrides.get(chainId);
+    if (override) {
+      return { rate: override.rate, address: override.address };
+    }
+
+    const cached = this.cache.get(chainId);
+    if (cached && Date.now() - cached.fetchedAt < this.ttlMs) {
+      return { rate: cached.rate, address: cached.address };
+    }
+
+    const vaultContract = this.vaultContracts.get(chainId);
+    if (!vaultContract || !vaultContract.provider) {
+      return { rate: ethers.constants.One, address: null };
+    }
+
+    let savingsAddress: string | null = null;
+    let rate: ethers.BigNumber;
+    try {
+      const probedSavingsAddress = await vaultContract.SAVINGS();
+      savingsAddress = probedSavingsAddress;
+      const savingsContract = this.contractFactory(
+        probedSavingsAddress,
+        SAVINGS_ABI,
+        vaultContract.provider,
+      );
+      rate = ethers.BigNumber.from(await savingsContract.currentRatePPM());
+    } catch (error) {
+      if (cached) {
+        this.logger.warn(
+          {
+            chainId,
+            savingsVaultAddress,
+            savingsAddress,
+            cachedRate: cached.rate.toString(),
+            cachedSavingsAddress: cached.address,
+            error,
+          },
+          "Savings currentRatePPM probe failed; using stale cached rate",
+        );
+        return { rate: cached.rate, address: cached.address };
+      }
+
+      this.logger.warn(
+        { chainId, savingsVaultAddress, savingsAddress, error },
+        "Savings currentRatePPM probe failed; blocking Gateway deposit route",
+      );
+      return { rate: ethers.constants.Zero, address: savingsAddress };
+    }
+
+    this.cache.set(chainId, {
+      rate,
+      fetchedAt: Date.now(),
+      address: savingsAddress,
+    });
+    return { rate, address: savingsAddress };
+  }
+}

--- a/src/services/SavingsRateProbe.ts
+++ b/src/services/SavingsRateProbe.ts
@@ -11,6 +11,11 @@ export interface SavingsRateProbeResult {
   address: string | null;
 }
 
+export interface SavingsRateProbeMetrics {
+  probeFailures: number;
+  currentRatePpm: Record<string, number>;
+}
+
 export type SavingsRateContractFactory = (
   address: string,
   abi: string[],
@@ -22,19 +27,25 @@ interface SavingsRateProbeOptions {
   contractFactory?: SavingsRateContractFactory;
 }
 
+interface CacheEntry {
+  rate: ethers.BigNumber;
+  fetchedAt: number;
+  address: string | null;
+}
+
 export class SavingsRateProbe {
   private logger: Logger;
   private ttlMs: number;
   private contractFactory: SavingsRateContractFactory;
   private vaultContracts: Map<ChainId, ethers.Contract> = new Map();
-  private cache: Map<
-    ChainId,
-    { rate: ethers.BigNumber; fetchedAt: number; address: string | null }
-  > = new Map();
+  private cache: Map<ChainId, CacheEntry> = new Map();
   private overrides: Map<
     ChainId,
     { rate: ethers.BigNumber; address: string | null }
   > = new Map();
+  private inFlight: Map<ChainId, Promise<void>> = new Map();
+  private probeFailures = 0;
+  private ratePpmByChain: Map<ChainId, number> = new Map();
 
   constructor(logger: Logger, options: SavingsRateProbeOptions = {}) {
     this.logger = logger.child({ service: "SavingsRateProbe" });
@@ -60,11 +71,10 @@ export class SavingsRateProbe {
     rate: ethers.BigNumberish,
     address: string | null = null,
   ): void {
-    this.overrides.set(chainId, {
-      rate: ethers.BigNumber.from(rate),
-      address,
-    });
+    const rateBn = ethers.BigNumber.from(rate);
+    this.overrides.set(chainId, { rate: rateBn, address });
     this.cache.delete(chainId);
+    this.ratePpmByChain.set(chainId, rateBn.toNumber());
   }
 
   clearOverride(chainId?: ChainId): void {
@@ -73,6 +83,27 @@ export class SavingsRateProbe {
       return;
     }
     this.overrides.delete(chainId);
+  }
+
+  /**
+   * Telemetry snapshot for the /metrics endpoint.
+   * - probeFailures: number of failed currentRatePPM probes since startup.
+   * - currentRatePpm: last observed savings rate per chainId.
+   */
+  getMetrics(): SavingsRateProbeMetrics {
+    const currentRatePpm: Record<string, number> = {};
+    for (const [chainId, rate] of this.ratePpmByChain) {
+      currentRatePpm[String(chainId)] = rate;
+    }
+    return { probeFailures: this.probeFailures, currentRatePpm };
+  }
+
+  /**
+   * Resolve once every in-flight background refresh has settled.
+   * Used by tests and for graceful diagnostics; production callers never await it.
+   */
+  async idle(): Promise<void> {
+    await Promise.all(Array.from(this.inFlight.values()));
   }
 
   async getCurrentRate(
@@ -91,9 +122,50 @@ export class SavingsRateProbe {
 
     const vaultContract = this.vaultContracts.get(chainId);
     if (!vaultContract || !vaultContract.provider) {
+      if (cached) {
+        return { rate: cached.rate, address: cached.address };
+      }
+      // Fail open: no integration vault registered, so we cannot prove the
+      // rate is zero. Blocking here would brick still-working chains.
+      this.logger.warn(
+        { chainId, savingsVaultAddress },
+        "Savings vault not registered; allowing Gateway deposit route (fail-open)",
+      );
       return { rate: ethers.constants.One, address: null };
     }
 
+    if (cached) {
+      // Stale-while-revalidate: hand back the stale rate immediately and
+      // refresh in the background so request latency never pays for the probe.
+      this.scheduleRefresh(chainId, vaultContract, savingsVaultAddress);
+      return { rate: cached.rate, address: cached.address };
+    }
+
+    // Cold cache: block on the first probe so the caller gets a real answer.
+    return this.refresh(chainId, vaultContract, savingsVaultAddress);
+  }
+
+  private scheduleRefresh(
+    chainId: ChainId,
+    vaultContract: ethers.Contract,
+    savingsVaultAddress: string | null,
+  ): void {
+    if (this.inFlight.has(chainId)) return;
+    const task = this.refresh(chainId, vaultContract, savingsVaultAddress)
+      .then(() => undefined)
+      .catch(() => undefined)
+      .finally(() => {
+        this.inFlight.delete(chainId);
+      });
+    this.inFlight.set(chainId, task);
+  }
+
+  private async refresh(
+    chainId: ChainId,
+    vaultContract: ethers.Contract,
+    savingsVaultAddress: string | null,
+  ): Promise<SavingsRateProbeResult> {
+    const cached = this.cache.get(chainId);
     let savingsAddress: string | null = null;
     let rate: ethers.BigNumber;
     try {
@@ -106,6 +178,7 @@ export class SavingsRateProbe {
       );
       rate = ethers.BigNumber.from(await savingsContract.currentRatePPM());
     } catch (error) {
+      this.probeFailures += 1;
       if (cached) {
         this.logger.warn(
           {
@@ -133,6 +206,7 @@ export class SavingsRateProbe {
       fetchedAt: Date.now(),
       address: savingsAddress,
     });
+    this.ratePpmByChain.set(chainId, rate.toNumber());
     return { rate, address: savingsAddress };
   }
 }

--- a/src/services/__tests__/JuiceGatewayService.test.ts
+++ b/src/services/__tests__/JuiceGatewayService.test.ts
@@ -23,6 +23,13 @@ describe("JuiceGatewayService.prepareQuote()", () => {
   const SV_JUSD = contracts.SV_JUSD;
   const USDC = contracts.USDC;
   const WCBTC = contracts.WCBTC;
+  const SAVINGS = "0x0000000000000000000000000000000000000001";
+  const BRIDGED_STABLES = [
+    ["SUSD", contracts.SUSD],
+    ["USDC", contracts.USDC],
+    ["USDT", contracts.USDT],
+    ["CTUSD", contracts.CTUSD],
+  ].filter(([, address]) => Boolean(address));
 
   beforeEach(() => {
     // Create service with empty providers (no RPC calls will be made)
@@ -178,5 +185,136 @@ describe("JuiceGatewayService.prepareQuote()", () => {
       expect(result!.routingType).toBe("GATEWAY_JUSD");
       expect(result!.internalTokenOut).toBe(SV_JUSD);
     });
+  });
+
+  describe("Savings disabled deposit gate", () => {
+    beforeEach(() => {
+      service.setSavingsRateOverride(chainId, 0, SAVINGS);
+    });
+
+    it.each([
+      ["JUSD -> cBTC", JUSD, WCBTC],
+      ["JUSD -> svJUSD", JUSD, SV_JUSD],
+      ["JUICE -> cBTC", JUICE, WCBTC],
+    ])(
+      "rejects %s with GATEWAY_DEPOSIT_DISABLED",
+      async (_name, input, output) => {
+        await expect(
+          service.prepareQuote(chainId, input, output, "1000000000000000000"),
+        ).rejects.toMatchObject({
+          code: "GATEWAY_DEPOSIT_DISABLED",
+          savingsRate: "0",
+          savingsAddress: SAVINGS,
+        });
+      },
+    );
+
+    it.each(BRIDGED_STABLES)(
+      "rejects %s -> cBTC with GATEWAY_DEPOSIT_DISABLED",
+      async (_symbol, bridgedToken) => {
+        await expect(
+          service.prepareQuote(
+            chainId,
+            bridgedToken,
+            WCBTC,
+            "1000000000000000000",
+          ),
+        ).rejects.toMatchObject({
+          code: "GATEWAY_DEPOSIT_DISABLED",
+          savingsRate: "0",
+          savingsAddress: SAVINGS,
+        });
+      },
+    );
+
+    it.each(BRIDGED_STABLES)(
+      "rejects %s -> svJUSD with GATEWAY_DEPOSIT_DISABLED",
+      async (_symbol, bridgedToken) => {
+        await expect(
+          service.prepareQuote(
+            chainId,
+            bridgedToken,
+            SV_JUSD,
+            "1000000000000000000",
+          ),
+        ).rejects.toMatchObject({
+          code: "GATEWAY_DEPOSIT_DISABLED",
+          savingsRate: "0",
+          savingsAddress: SAVINGS,
+        });
+      },
+    );
+
+    it("exposes the same gate for swap calldata builders", async () => {
+      await expect(
+        service.rejectIfRouteRequiresJusdDepositDisabled(
+          chainId,
+          JUICE,
+          WCBTC,
+          "GATEWAY_JUICE_IN",
+        ),
+      ).rejects.toMatchObject({
+        code: "GATEWAY_DEPOSIT_DISABLED",
+      });
+    });
+
+    it("keeps cBTC -> JUSD available", async () => {
+      const result = await service.prepareQuote(
+        chainId,
+        WCBTC,
+        JUSD,
+        "100000000",
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.routingType).toBe("GATEWAY_JUSD");
+      expect(result!.internalTokenOut).toBe(SV_JUSD);
+    });
+
+    it("keeps svJUSD -> cBTC available", async () => {
+      const result = await service.prepareQuote(
+        chainId,
+        SV_JUSD,
+        WCBTC,
+        "1000000000000000000",
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.routingType).toBe("GATEWAY_JUSD");
+      expect(result!.internalTokenIn).toBe(SV_JUSD);
+    });
+
+    it("keeps JUSD -> JUICE available", async () => {
+      jest
+        .spyOn(service, "jusdToJuice")
+        .mockResolvedValue("950000000000000000");
+
+      const result = await service.prepareQuote(
+        chainId,
+        JUSD,
+        JUICE,
+        "1000000000000000000",
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.isDirectConversion).toBe(true);
+      expect(result!.expectedOutput).toBe("950000000000000000");
+    });
+  });
+
+  it("allows deposit routes again when the Savings rate is non-zero", async () => {
+    service.setSavingsRateOverride(chainId, 100000, SAVINGS);
+    jest.spyOn(service, "jusdToSvJusd").mockResolvedValue("970000000000000000");
+
+    const result = await service.prepareQuote(
+      chainId,
+      JUSD,
+      WCBTC,
+      "1000000000000000000",
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.internalTokenIn).toBe(SV_JUSD);
+    expect(result!.internalAmountIn).toBe("970000000000000000");
   });
 });

--- a/src/services/__tests__/JuiceGatewayService.test.ts
+++ b/src/services/__tests__/JuiceGatewayService.test.ts
@@ -345,4 +345,33 @@ describe("JuiceGatewayService.prepareQuote()", () => {
     expect(result!.internalTokenIn).toBe(SV_JUSD);
     expect(result!.internalAmountIn).toBe("970000000000000000");
   });
+
+  describe("LP routing scope (enabled state)", () => {
+    // The Gateway LP handlers only convert literal JUSD legs to svJUSD. If
+    // detectLpGatewayRouting/getInternalPoolToken routed bridged stablecoin or
+    // JUICE legs through the Gateway LP path, those legs would be fed into the
+    // svJUSD position math with raw, unconverted amounts. These guard against
+    // re-introducing that scope creep.
+
+    it("routes JUSD LP legs through the Gateway", () => {
+      expect(service.detectLpGatewayRouting(chainId, JUSD, WCBTC)).toBe(true);
+      expect(service.detectLpGatewayRouting(chainId, WCBTC, JUSD)).toBe(true);
+      expect(service.getInternalPoolToken(chainId, JUSD)).toBe(SV_JUSD);
+    });
+
+    it("does NOT route bridged stablecoin LP legs through the Gateway", () => {
+      for (const [, address] of BRIDGED_STABLES) {
+        expect(service.detectLpGatewayRouting(chainId, address, WCBTC)).toBe(
+          false,
+        );
+        // Bridged legs must stay as themselves, never silently mapped to svJUSD.
+        expect(service.getInternalPoolToken(chainId, address)).toBe(address);
+      }
+    });
+
+    it("does NOT route JUICE LP legs through the Gateway", () => {
+      expect(service.detectLpGatewayRouting(chainId, JUICE, WCBTC)).toBe(false);
+      expect(service.getInternalPoolToken(chainId, JUICE)).toBe(JUICE);
+    });
+  });
 });

--- a/src/services/__tests__/JuiceGatewayService.test.ts
+++ b/src/services/__tests__/JuiceGatewayService.test.ts
@@ -258,6 +258,16 @@ describe("JuiceGatewayService.prepareQuote()", () => {
       });
     });
 
+    it("counts blocked deposits and exposes the rate in the metrics snapshot", async () => {
+      await expect(
+        service.prepareQuote(chainId, JUSD, WCBTC, "1000000000000000000"),
+      ).rejects.toMatchObject({ code: "GATEWAY_DEPOSIT_DISABLED" });
+
+      const metrics = service.getMetrics();
+      expect(metrics.blockedDeposits[`${chainId}:GATEWAY_JUSD`]).toBe(1);
+      expect(metrics.savingsRate.currentRatePpm[String(chainId)]).toBe(0);
+    });
+
     it("keeps cBTC -> JUSD available", async () => {
       const result = await service.prepareQuote(
         chainId,

--- a/src/services/__tests__/JuiceGatewayService.test.ts
+++ b/src/services/__tests__/JuiceGatewayService.test.ts
@@ -312,6 +312,24 @@ describe("JuiceGatewayService.prepareQuote()", () => {
     });
   });
 
+  it("applies the deposit gate on Citrea Testnet as well", async () => {
+    const testnetChain = ChainId.CITREA_TESTNET;
+    const testnetContracts = getChainContracts(testnetChain)!;
+    service.setSavingsRateOverride(testnetChain, 0, SAVINGS);
+
+    await expect(
+      service.prepareQuote(
+        testnetChain,
+        testnetContracts.JUSD,
+        testnetContracts.WCBTC,
+        "1000000000000000000",
+      ),
+    ).rejects.toMatchObject({
+      code: "GATEWAY_DEPOSIT_DISABLED",
+      savingsRate: "0",
+    });
+  });
+
   it("allows deposit routes again when the Savings rate is non-zero", async () => {
     service.setSavingsRateOverride(chainId, 100000, SAVINGS);
     jest.spyOn(service, "jusdToSvJusd").mockResolvedValue("970000000000000000");

--- a/src/services/__tests__/SavingsRateProbe.integration.test.ts
+++ b/src/services/__tests__/SavingsRateProbe.integration.test.ts
@@ -1,0 +1,123 @@
+import { ethers } from "ethers";
+import { ChainId } from "@juiceswapxyz/sdk-core";
+import Logger from "bunyan";
+import { SavingsRateProbe } from "../SavingsRateProbe";
+import { JuiceGatewayService } from "../JuiceGatewayService";
+import { getChainContracts } from "../../config/contracts";
+
+/**
+ * Live integration test against Citrea Mainnet (chain 4114). Opt-in only:
+ * set RUN_CITREA_INTEGRATION=1 to run. It hits the public RPC, so it stays
+ * out of the deterministic unit-test CI matrix.
+ *
+ * Verifies the root cause from issue #263 still holds and that the API-side
+ * gate reacts to the live Savings rate:
+ *   - SavingsRateProbe reads currentRatePPM() == 0 from the on-chain Savings.
+ *   - Savings.save(...) reverts with ModuleDisabled() (0x6dff2fe8).
+ *   - JUSD -> cBTC is gated (GATEWAY_DEPOSIT_DISABLED) end-to-end.
+ *   - JUSD -> CTUSD (direct USD conversion) is NOT gated.
+ */
+const RUN = process.env.RUN_CITREA_INTEGRATION === "1";
+const RPC_URL =
+  process.env.CITREA_4114_RPC_URL || "https://rpc.citreascan.com/";
+const MODULE_DISABLED_SELECTOR = "0x6dff2fe8"; // keccak256("ModuleDisabled()")[:4]
+const SAVINGS_ABI = [
+  "function currentRatePPM() view returns (uint24)",
+  "function save(address owner, uint192 amount)",
+];
+
+function createSilentLogger(): Logger {
+  const logger = {
+    child: () => logger,
+    info: () => undefined,
+    debug: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+  };
+  return logger as unknown as Logger;
+}
+
+(RUN ? describe : describe.skip)(
+  "SavingsRateProbe (Citrea Mainnet integration)",
+  () => {
+    jest.setTimeout(60_000);
+
+    const chainId = ChainId.CITREA_MAINNET;
+    const contracts = getChainContracts(chainId)!;
+    let provider: ethers.providers.StaticJsonRpcProvider;
+
+    beforeAll(() => {
+      provider = new ethers.providers.StaticJsonRpcProvider(RPC_URL, {
+        chainId,
+        name: "citrea-mainnet",
+      });
+    });
+
+    it("reads currentRatePPM() == 0 from the live Savings contract", async () => {
+      const probe = new SavingsRateProbe(createSilentLogger());
+      probe.registerVault(chainId, contracts.SV_JUSD, provider);
+
+      const result = await probe.getCurrentRate(chainId, contracts.SV_JUSD);
+
+      // The savings rate has been at 0 since the outage began (issue #263).
+      expect(result.rate.isZero()).toBe(true);
+      expect(result.address).toMatch(/^0x[0-9a-fA-F]{40}$/);
+    });
+
+    it("Savings.save(...) reverts with ModuleDisabled() (0x6dff2fe8)", async () => {
+      const probe = new SavingsRateProbe(createSilentLogger());
+      probe.registerVault(chainId, contracts.SV_JUSD, provider);
+      const { address: savingsAddress } = await probe.getCurrentRate(
+        chainId,
+        contracts.SV_JUSD,
+      );
+      expect(savingsAddress).not.toBeNull();
+
+      const savings = new ethers.Contract(
+        savingsAddress as string,
+        SAVINGS_ABI,
+        provider,
+      );
+
+      let revertData = "";
+      try {
+        await savings.callStatic.save(
+          "0x000000000000000000000000000000000000dEaD",
+          ethers.utils.parseUnits("1", 18),
+        );
+        throw new Error("save() did not revert");
+      } catch (error) {
+        revertData = JSON.stringify(error);
+      }
+
+      expect(revertData).toContain(MODULE_DISABLED_SELECTOR);
+    });
+
+    it("gates JUSD -> cBTC but not JUSD -> CTUSD against live state", async () => {
+      const service = new JuiceGatewayService(
+        new Map([[chainId, provider]]),
+        createSilentLogger(),
+      );
+
+      // Deposit-bound route must be rejected.
+      await expect(
+        service.rejectIfRouteRequiresJusdDepositDisabled(
+          chainId,
+          contracts.JUSD,
+          contracts.WCBTC,
+          "GATEWAY_JUSD",
+        ),
+      ).rejects.toMatchObject({ code: "GATEWAY_DEPOSIT_DISABLED" });
+
+      // Direct USD conversion bypasses the vault and must stay available.
+      await expect(
+        service.rejectIfRouteRequiresJusdDepositDisabled(
+          chainId,
+          contracts.JUSD,
+          contracts.CTUSD,
+          "GATEWAY_JUSD",
+        ),
+      ).resolves.toBeUndefined();
+    });
+  },
+);

--- a/src/services/__tests__/SavingsRateProbe.test.ts
+++ b/src/services/__tests__/SavingsRateProbe.test.ts
@@ -201,6 +201,40 @@ describe("SavingsRateProbe", () => {
     expect(currentRatePPM).toHaveBeenCalledTimes(2);
   });
 
+  it("coalesces concurrent cold-cache callers into one probe (no thundering herd)", async () => {
+    const savings = jest.fn().mockResolvedValue(savingsAddress);
+    const currentRatePPM = jest.fn().mockResolvedValue(42);
+    const factory: SavingsRateContractFactory = (address, abi, provider) => {
+      if (abi[0].includes("SAVINGS()")) {
+        return { provider, SAVINGS: savings } as unknown as ethers.Contract;
+      }
+      return {
+        provider,
+        currentRatePPM,
+      } as unknown as ethers.Contract;
+    };
+    const probe = new SavingsRateProbe(createMockLogger(), {
+      ttlMs: 60_000,
+      contractFactory: factory,
+    });
+
+    probe.registerVault(chainId, vaultAddress, {} as ethers.providers.Provider);
+
+    // Three first-callers race before the cache is warm; they must share one
+    // SAVINGS()+currentRatePPM() probe rather than each firing its own.
+    const [a, b, c] = await Promise.all([
+      probe.getCurrentRate(chainId, vaultAddress),
+      probe.getCurrentRate(chainId, vaultAddress),
+      probe.getCurrentRate(chainId, vaultAddress),
+    ]);
+
+    expect(a.rate.toString()).toBe("42");
+    expect(b.rate.toString()).toBe("42");
+    expect(c.rate.toString()).toBe("42");
+    expect(savings).toHaveBeenCalledTimes(1);
+    expect(currentRatePPM).toHaveBeenCalledTimes(1);
+  });
+
   it("exposes the override rate through the metrics gauge", async () => {
     const probe = new SavingsRateProbe(createMockLogger());
 
@@ -217,6 +251,9 @@ describe("SavingsRateProbe", () => {
     );
 
     probe.clearOverride(chainId);
+
+    // The override-seeded gauge value is dropped, not left stale at 0.
+    expect(probe.getMetrics().currentRatePpm[String(chainId)]).toBeUndefined();
 
     // No vault registered after clearing → fail-open rate of 1.
     const result = await probe.getCurrentRate(chainId, vaultAddress);

--- a/src/services/__tests__/SavingsRateProbe.test.ts
+++ b/src/services/__tests__/SavingsRateProbe.test.ts
@@ -246,9 +246,9 @@ describe("SavingsRateProbe", () => {
   it("clears a per-chain override and falls back to normal resolution", async () => {
     const probe = new SavingsRateProbe(createMockLogger());
     probe.setOverride(chainId, 0, savingsAddress);
-    expect((await probe.getCurrentRate(chainId, vaultAddress)).rate.isZero()).toBe(
-      true,
-    );
+    expect(
+      (await probe.getCurrentRate(chainId, vaultAddress)).rate.isZero(),
+    ).toBe(true);
 
     probe.clearOverride(chainId);
 

--- a/src/services/__tests__/SavingsRateProbe.test.ts
+++ b/src/services/__tests__/SavingsRateProbe.test.ts
@@ -1,0 +1,134 @@
+import { ethers } from "ethers";
+import { ChainId } from "@juiceswapxyz/sdk-core";
+import Logger from "bunyan";
+import {
+  SavingsRateContractFactory,
+  SavingsRateProbe,
+} from "../SavingsRateProbe";
+
+function createMockLogger(): Logger {
+  const logger = {
+    child: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+  return logger as unknown as Logger;
+}
+
+describe("SavingsRateProbe", () => {
+  const chainId = ChainId.CITREA_MAINNET;
+  const vaultAddress = "0x0000000000000000000000000000000000000001";
+  const savingsAddress = "0x0000000000000000000000000000000000000002";
+
+  it("returns the runtime override without requiring an RPC contract", async () => {
+    const probe = new SavingsRateProbe(createMockLogger());
+
+    probe.setOverride(chainId, 0, savingsAddress);
+
+    const result = await probe.getCurrentRate(chainId, vaultAddress);
+    expect(result.rate.isZero()).toBe(true);
+    expect(result.address).toBe(savingsAddress);
+  });
+
+  it("caches the probed rate within the configured TTL", async () => {
+    const savings = jest.fn().mockResolvedValue(savingsAddress);
+    const currentRatePPM = jest
+      .fn()
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(123);
+    const factory: SavingsRateContractFactory = (address, abi, provider) => {
+      if (abi[0].includes("SAVINGS()")) {
+        expect(address).toBe(vaultAddress);
+        return { provider, SAVINGS: savings } as unknown as ethers.Contract;
+      }
+      expect(address).toBe(savingsAddress);
+      return {
+        provider,
+        currentRatePPM,
+      } as unknown as ethers.Contract;
+    };
+    const probe = new SavingsRateProbe(createMockLogger(), {
+      ttlMs: 60_000,
+      contractFactory: factory,
+    });
+
+    probe.registerVault(chainId, vaultAddress, {} as ethers.providers.Provider);
+
+    const first = await probe.getCurrentRate(chainId, vaultAddress);
+    const second = await probe.getCurrentRate(chainId, vaultAddress);
+
+    expect(first.rate.toString()).toBe("0");
+    expect(second.rate.toString()).toBe("0");
+    expect(savings).toHaveBeenCalledTimes(1);
+    expect(currentRatePPM).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a stale cached zero rate when refresh probing fails", async () => {
+    const savings = jest.fn().mockResolvedValue(savingsAddress);
+    const currentRatePPM = jest
+      .fn()
+      .mockResolvedValueOnce(0)
+      .mockRejectedValueOnce(new Error("rpc unavailable"));
+    const factory: SavingsRateContractFactory = (address, abi, provider) => {
+      if (abi[0].includes("SAVINGS()")) {
+        return { provider, SAVINGS: savings } as unknown as ethers.Contract;
+      }
+      expect(address).toBe(savingsAddress);
+      return {
+        provider,
+        currentRatePPM,
+      } as unknown as ethers.Contract;
+    };
+    const probe = new SavingsRateProbe(createMockLogger(), {
+      ttlMs: 0,
+      contractFactory: factory,
+    });
+
+    probe.registerVault(chainId, vaultAddress, {} as ethers.providers.Provider);
+
+    const first = await probe.getCurrentRate(chainId, vaultAddress);
+    const second = await probe.getCurrentRate(chainId, vaultAddress);
+
+    expect(first.rate.toString()).toBe("0");
+    expect(second.rate.toString()).toBe("0");
+    expect(second.address).toBe(savingsAddress);
+    expect(currentRatePPM).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails closed when an initial probe fails for a registered vault", async () => {
+    const savings = jest.fn().mockResolvedValue(savingsAddress);
+    const currentRatePPM = jest.fn().mockRejectedValue(new Error("rpc down"));
+    const factory: SavingsRateContractFactory = (address, abi, provider) => {
+      if (abi[0].includes("SAVINGS()")) {
+        return { provider, SAVINGS: savings } as unknown as ethers.Contract;
+      }
+      expect(address).toBe(savingsAddress);
+      return {
+        provider,
+        currentRatePPM,
+      } as unknown as ethers.Contract;
+    };
+    const probe = new SavingsRateProbe(createMockLogger(), {
+      contractFactory: factory,
+    });
+
+    probe.registerVault(chainId, vaultAddress, {} as ethers.providers.Provider);
+
+    const result = await probe.getCurrentRate(chainId, vaultAddress);
+
+    expect(result.rate.isZero()).toBe(true);
+    expect(result.address).toBe(savingsAddress);
+  });
+
+  it("fails open when no vault has been registered", async () => {
+    const probe = new SavingsRateProbe(createMockLogger());
+
+    const result = await probe.getCurrentRate(chainId, vaultAddress);
+
+    expect(result.rate.eq(ethers.constants.One)).toBe(true);
+    expect(result.address).toBeNull();
+  });
+});

--- a/src/services/__tests__/SavingsRateProbe.test.ts
+++ b/src/services/__tests__/SavingsRateProbe.test.ts
@@ -90,12 +90,16 @@ describe("SavingsRateProbe", () => {
     probe.registerVault(chainId, vaultAddress, {} as ethers.providers.Provider);
 
     const first = await probe.getCurrentRate(chainId, vaultAddress);
+    // Stale entry is served immediately; the failing refresh runs in the
+    // background and must not overwrite the cached value.
     const second = await probe.getCurrentRate(chainId, vaultAddress);
+    await probe.idle();
 
     expect(first.rate.toString()).toBe("0");
     expect(second.rate.toString()).toBe("0");
     expect(second.address).toBe(savingsAddress);
     expect(currentRatePPM).toHaveBeenCalledTimes(2);
+    expect(probe.getMetrics().probeFailures).toBe(1);
   });
 
   it("fails closed when an initial probe fails for a registered vault", async () => {
@@ -130,5 +134,78 @@ describe("SavingsRateProbe", () => {
 
     expect(result.rate.eq(ethers.constants.One)).toBe(true);
     expect(result.address).toBeNull();
+  });
+
+  it("serves a stale rate immediately and revalidates in the background", async () => {
+    const savings = jest.fn().mockResolvedValue(savingsAddress);
+    const currentRatePPM = jest
+      .fn()
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(123);
+    const factory: SavingsRateContractFactory = (address, abi, provider) => {
+      if (abi[0].includes("SAVINGS()")) {
+        return { provider, SAVINGS: savings } as unknown as ethers.Contract;
+      }
+      return {
+        provider,
+        currentRatePPM,
+      } as unknown as ethers.Contract;
+    };
+    const probe = new SavingsRateProbe(createMockLogger(), {
+      ttlMs: 0,
+      contractFactory: factory,
+    });
+
+    probe.registerVault(chainId, vaultAddress, {} as ethers.providers.Provider);
+
+    const first = await probe.getCurrentRate(chainId, vaultAddress);
+    const second = await probe.getCurrentRate(chainId, vaultAddress);
+    await probe.idle();
+
+    // The stale (0) rate is returned synchronously; the fresh 123 only lands
+    // in the cache/gauge after the background refresh settles.
+    expect(first.rate.toString()).toBe("0");
+    expect(second.rate.toString()).toBe("0");
+    expect(currentRatePPM).toHaveBeenCalledTimes(2);
+    expect(probe.getMetrics().currentRatePpm[String(chainId)]).toBe(123);
+  });
+
+  it("coalesces concurrent background refreshes into one probe", async () => {
+    const savings = jest.fn().mockResolvedValue(savingsAddress);
+    const currentRatePPM = jest
+      .fn()
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(123);
+    const factory: SavingsRateContractFactory = (address, abi, provider) => {
+      if (abi[0].includes("SAVINGS()")) {
+        return { provider, SAVINGS: savings } as unknown as ethers.Contract;
+      }
+      return {
+        provider,
+        currentRatePPM,
+      } as unknown as ethers.Contract;
+    };
+    const probe = new SavingsRateProbe(createMockLogger(), {
+      ttlMs: 0,
+      contractFactory: factory,
+    });
+
+    probe.registerVault(chainId, vaultAddress, {} as ethers.providers.Provider);
+
+    await probe.getCurrentRate(chainId, vaultAddress); // cold blocking probe
+    await probe.getCurrentRate(chainId, vaultAddress); // schedules one refresh
+    await probe.getCurrentRate(chainId, vaultAddress); // in-flight, no extra probe
+    await probe.idle();
+
+    // 1 cold probe + 1 coalesced background refresh = 2 (never 3).
+    expect(currentRatePPM).toHaveBeenCalledTimes(2);
+  });
+
+  it("exposes the override rate through the metrics gauge", async () => {
+    const probe = new SavingsRateProbe(createMockLogger());
+
+    probe.setOverride(chainId, 0, savingsAddress);
+
+    expect(probe.getMetrics().currentRatePpm[String(chainId)]).toBe(0);
   });
 });

--- a/src/services/__tests__/SavingsRateProbe.test.ts
+++ b/src/services/__tests__/SavingsRateProbe.test.ts
@@ -208,4 +208,28 @@ describe("SavingsRateProbe", () => {
 
     expect(probe.getMetrics().currentRatePpm[String(chainId)]).toBe(0);
   });
+
+  it("clears a per-chain override and falls back to normal resolution", async () => {
+    const probe = new SavingsRateProbe(createMockLogger());
+    probe.setOverride(chainId, 0, savingsAddress);
+    expect((await probe.getCurrentRate(chainId, vaultAddress)).rate.isZero()).toBe(
+      true,
+    );
+
+    probe.clearOverride(chainId);
+
+    // No vault registered after clearing → fail-open rate of 1.
+    const result = await probe.getCurrentRate(chainId, vaultAddress);
+    expect(result.rate.eq(ethers.constants.One)).toBe(true);
+  });
+
+  it("clears every override when called without a chainId", async () => {
+    const probe = new SavingsRateProbe(createMockLogger());
+    probe.setOverride(chainId, 0, savingsAddress);
+
+    probe.clearOverride();
+
+    const result = await probe.getCurrentRate(chainId, vaultAddress);
+    expect(result.rate.eq(ethers.constants.One)).toBe(true);
+  });
 });

--- a/src/services/__tests__/SavingsRateProbe.test.ts
+++ b/src/services/__tests__/SavingsRateProbe.test.ts
@@ -235,6 +235,43 @@ describe("SavingsRateProbe", () => {
     expect(currentRatePPM).toHaveBeenCalledTimes(1);
   });
 
+  it("does not let an in-flight probe resurrect a rate after setOverride", async () => {
+    let resolveRate: (value: number) => void = () => undefined;
+    const ratePromise = new Promise<number>((resolve) => {
+      resolveRate = resolve;
+    });
+    const savings = jest.fn().mockResolvedValue(savingsAddress);
+    const currentRatePPM = jest.fn().mockReturnValue(ratePromise);
+    const factory: SavingsRateContractFactory = (address, abi, provider) => {
+      if (abi[0].includes("SAVINGS()")) {
+        return { provider, SAVINGS: savings } as unknown as ethers.Contract;
+      }
+      return {
+        provider,
+        currentRatePPM,
+      } as unknown as ethers.Contract;
+    };
+    const probe = new SavingsRateProbe(createMockLogger(), {
+      ttlMs: 60_000,
+      contractFactory: factory,
+    });
+    probe.registerVault(chainId, vaultAddress, {} as ethers.providers.Provider);
+
+    // Start a cold probe, then force an override before the probe resolves.
+    const inflight = probe.getCurrentRate(chainId, vaultAddress);
+    probe.setOverride(chainId, 0, savingsAddress);
+    resolveRate(500_000); // late probe returns a non-zero (deposit-enabled) rate
+    await inflight;
+    await probe.idle();
+
+    // Override stays authoritative for gating AND telemetry; the stale 500000
+    // must never reach the cache or the gauge.
+    expect(
+      (await probe.getCurrentRate(chainId, vaultAddress)).rate.toString(),
+    ).toBe("0");
+    expect(probe.getMetrics().currentRatePpm[String(chainId)]).toBe(0);
+  });
+
   it("exposes the override rate through the metrics gauge", async () => {
     const probe = new SavingsRateProbe(createMockLogger());
 


### PR DESCRIPTION
## Summary
- add cached Savings rate probing with test override and fail-closed behavior for registered vault probe failures
- block Gateway deposit routes for JUSD/bridged/JUICE inputs across quote, swap, GraphQL quote, and LP create/increase
- prevent stale cached quotes from bypassing the deposit-disabled gate
- add regression coverage for bridged stablecoins, GraphQL, stale cache, LP early gating, and probe failure cases

## Root cause
Savings.currentRatePPM() is 0 on Citrea Mainnet, so svJUSD deposits revert with ModuleDisabled(). Existing quote/swap paths still produced calldata for Gateway routes that must deposit into svJUSD.

## Validation
- npm test -- --runInBand
- npm run typecheck
- npm run build
- npm run lint (0 errors, existing warnings)
- npx prettier --check src/**/*.ts
- git diff --check && git diff --cached --check
- tester/fixer loops with final tester pass reporting no findings

Fixes #263