### PR TITLE
Add launchpad token candle endpoint

### DIFF
--- a/docs/launchpad-token-charts-analysis.md
+++ b/docs/launchpad-token-charts-analysis.md
@@ -1,0 +1,600 @@
+# Launchpad Token Charts Analysis
+
+Date: 2026-05-31
+Repository: `JuiceSwap-api`
+Branch prepared: `joshua/launchpad-token-candles`
+Implementation status: Phase 1 API endpoint implemented in this branch as
+`GET /v1/launchpad/token/:address/candles`.
+
+## Scope
+
+This document reviews how to add Pump.fun-style charts for every JuiceSwap
+Launchpad token. It focuses on the API/indexer boundary because the frontend
+chart is straightforward once the backend exposes stable OHLCV data.
+
+The analysis uses:
+
+- Local `JuiceSwap-api` source.
+- Live Ponder API/schema checks against `https://ponder.juiceswap.com`.
+- Public `@juiceswapxyz/launchpad@3.0.0` package metadata and README.
+- Public JuiceSwap docs and TradingView Lightweight Charts docs.
+
+## Executive Decision
+
+Best approach: add an API-owned Launchpad candle endpoint backed by Ponder
+Launchpad trade data, with the API responsible for bucketing, price math,
+pagination, and cache control. In this branch the endpoint is intentionally
+Phase 1 only: it returns bonding-curve execution-price candles from
+`launchpadTrades`. For a graduated token, that means pre-graduation
+bonding-curve history plus a graduation marker, not fabricated V2 OHLC.
+
+Recommended endpoint:
+
+```text
+GET /v1/launchpad/token/:address/candles
+```
+
+Recommended query:
+
+```text
+chainId=4114
+interval=1m|5m|15m|1h|4h|1d
+from=epoch_seconds
+to=epoch_seconds
+limit=1000
+currency=base
+fill=none|last
+```
+
+Recommended response:
+
+```json
+{
+  "token": {
+    "address": "0x...",
+    "chainId": 4114,
+    "name": "Example",
+    "symbol": "EXM",
+    "graduated": false,
+    "canGraduate": false,
+    "progress": 1234,
+    "v2Pair": null
+  },
+  "quote": {
+    "address": "0x0987D3720D38847ac6dBB9D025B9dE892a3CA35C",
+    "symbol": "JUSD",
+    "decimals": 18
+  },
+  "source": "bonding_curve",
+  "priceBasis": "execution_price",
+  "candles": [
+    {
+      "time": 1780167060,
+      "open": 0.00000415,
+      "high": 0.00000415,
+      "low": 0.00000415,
+      "close": 0.00000415,
+      "volumeBase": 0.9801,
+      "volumeToken": 236008.07822279099,
+      "tradeCount": 1
+    }
+  ],
+  "latest": {
+    "price": 0.00000415,
+    "timestamp": 1780167091
+  }
+}
+```
+
+Why this is the best fit:
+
+- The existing launchpad REST endpoints only return lists, token details, and
+  raw paginated trades. The frontend should not have to page all trades and
+  reproduce price math.
+- Ponder already exposes enough data for a useful pre-graduation chart.
+- Post-graduation charts need more indexer data than the current public schema
+  exposes if we want correct historical OHLC, not just volume bars.
+- An API endpoint lets the frontend use a normal chart library and stay
+  independent from Ponder schema details.
+
+## API State Before This Branch
+
+Before this branch, the API had these Launchpad routes:
+
+- `GET /v1/launchpad/tokens`
+- `GET /v1/launchpad/token/:address`
+- `GET /v1/launchpad/token/:address/trades`
+- `GET /v1/launchpad/stats`
+- `GET /v1/launchpad/recent-trades`
+- metadata upload endpoints
+
+The handlers in `src/endpoints/launchpad.ts` are thin Ponder REST proxies. They
+validate addresses for token detail/trades and forward query parameters to
+Ponder. Before this branch, the route registration in `src/server.ts` and the
+validation schemas supported token list/trades/recent-trades only. This branch
+adds the token-candle endpoint listed above.
+
+Existing pool chart endpoints are useful references:
+
+- `GET /v1/pools/:address/price-history`
+- `GET /v1/pools/:address/volume-history`
+- `GET /v1/pools/:address/transactions`
+
+The V3 pool price endpoint reads `poolActivitys` from Ponder, converts
+`sqrtPriceX96` snapshots into price points, resamples by duration, and caches
+for 30 seconds. The V3 pool volume endpoint reads `poolStats` buckets and also
+caches for 30 seconds. The Launchpad candle endpoint should reuse those local
+patterns: `ResponseCache`, `PonderClient`, direct GraphQL queries, explicit
+duration mapping, and capped output.
+
+## Launchpad Contract Facts
+
+The public package `@juiceswapxyz/launchpad@3.0.0` describes the launchpad as a
+constant-product bonding curve with automatic JuiceSwap V2 graduation. All
+tokens trade against JUSD, graduation creates TOKEN/JUSD V2 pairs, and LP
+tokens are burned to `0xdead`.
+
+Important package/contract facts:
+
+- `TokenFactory` emits `TokenCreated`.
+- `BondingCurveToken` emits `Buy`, `Sell`, `ReadyForGraduation`, and
+  `Graduated`.
+- `Buy` includes buyer, base input, token output, and the new virtual reserves.
+- `Sell` includes seller, token input, base output, and the new virtual
+  reserves.
+- `Graduated` includes the V2 pair, liquidity locked, and protocol fees.
+- The launchpad constants are fixed around 1B total token supply, 793.1M real
+  tokens sold on curve, 206.9M reserved for V2 liquidity, and 1% fee.
+- Mainnet launchpad factory in the package is
+  `0xF5E06d37091a252A3Ae6BFd575D97635625028b9`.
+
+This is important for charts because the contract events contain more useful
+price-state information than the current `launchpadTrade` Ponder table exposes.
+
+## Live Ponder Schema Findings
+
+Live Ponder schema exposes these relevant query roots:
+
+- `launchpadToken`
+- `launchpadTokens`
+- `launchpadTrade`
+- `launchpadTrades`
+- `graduatedV2Pool`
+- `graduatedV2Pools`
+- `v2PoolStat`
+- `v2PoolStats`
+
+Live `launchpadToken` fields include:
+
+- `address`
+- `chainId`
+- `name`
+- `symbol`
+- `creator`
+- `baseAsset`
+- `metadataURI`
+- `createdAt`
+- `createdAtBlock`
+- `txHash`
+- `graduated`
+- `canGraduate`
+- `v2Pair`
+- `graduatedAt`
+- `totalBuys`
+- `totalSells`
+- `totalVolumeBase`
+- `lastTradeAt`
+- `progress`
+
+Live `launchpadTrade` fields include:
+
+- `id`
+- `tokenAddress`
+- `chainId`
+- `trader`
+- `isBuy`
+- `baseAmount`
+- `tokenAmount`
+- `timestamp`
+- `blockNumber`
+- `txHash`
+
+Live `graduatedV2Pool` fields include:
+
+- `pairAddress`
+- `chainId`
+- `token0`
+- `token1`
+- `launchpadTokenAddress`
+- `createdAt`
+- `createdAtBlock`
+- `txHash`
+- `totalSwaps`
+
+Live `v2PoolStat` fields include:
+
+- `poolAddress`
+- `chainId`
+- `timestamp`
+- `txCount`
+- `volume0`
+- `volume1`
+- `type`
+
+Mainnet live data currently confirms Launchpad data is populated: the Ponder
+list endpoint returned 118 launchpad tokens for chain `4114`, and
+`graduatedV2Pools` returned graduated TOKEN/JUSD pairs. The live data also
+confirms that `v2PoolStats` currently gives volume buckets but not historical
+price or swap-side details.
+
+## Data Adequacy
+
+### Pre-graduation bonding curve tokens
+
+Current data is enough for an MVP candlestick chart:
+
+```text
+executionPriceBasePerToken = baseAmount / tokenAmount
+```
+
+Both Launchpad token and JUSD use 18 decimals, but the service should still
+keep decimals explicit so the code remains correct if the base asset changes.
+
+For each bucket:
+
+- `open`: first trade execution price in the bucket.
+- `high`: max trade execution price.
+- `low`: min trade execution price.
+- `close`: last trade execution price.
+- `volumeBase`: sum of `baseAmount`.
+- `volumeToken`: sum of `tokenAmount`.
+- `tradeCount`: number of trades.
+
+Limitations:
+
+- This is execution-price OHLC, not exact post-trade spot-price OHLC.
+- Large bonding-curve trades can have meaningful average-vs-close difference.
+- Buy and sell amounts include fee effects differently: buy `baseAmount` is
+  gross user input, sell `baseAmount` is net output.
+
+Better chart data requires extending Ponder `launchpadTrade` to store the
+virtual reserves emitted in `Buy` and `Sell`. With post-trade reserves, the API
+can compute a reserve-price close:
+
+```text
+spotPriceBasePerToken = virtualBaseReserves / virtualTokenReserves
+```
+
+That produces a chart closer to a DEX "mark price", while still exposing volume
+from actual trades.
+
+### Post-graduation V2 tokens
+
+Current data is not enough for a full historical candlestick chart after
+graduation.
+
+What exists now:
+
+- `graduatedV2Pools` maps launchpad token to V2 pair.
+- `v2PoolStats` gives bucketed volume and tx count.
+- On-chain `getReserves()` can give current spot price.
+
+What is missing for historical OHLC:
+
+- Per-swap V2 event records for graduated pairs.
+- Amount direction, e.g. `amount0In`, `amount1In`, `amount0Out`,
+  `amount1Out`.
+- Pair reserves after swap, or at least a post-swap price snapshot.
+
+Recommendation: extend the Ponder indexer with a table like
+`graduatedV2Swap`:
+
+```text
+id
+chainId
+pairAddress
+launchpadTokenAddress
+trader or sender
+recipient
+token0
+token1
+amount0In
+amount1In
+amount0Out
+amount1Out
+reserve0After
+reserve1After
+timestamp
+blockNumber
+txHash
+logIndex
+```
+
+Then API can compute post-graduation candles using the same bucket logic as
+bonding-curve trades.
+
+Future V2/indexer-extension option if Ponder indexer changes are not
+immediately available:
+
+- Show bonding-curve candles up to graduation.
+- Show current V2 price from `getReserves()`.
+- Show post-graduation volume bars from `v2PoolStats`.
+- Mark the chart response as `source: "partial_post_graduation"`.
+
+Do not fake historical V2 OHLC from `v2PoolStats`; volume-only buckets do not
+contain price. Phase 1 in this branch does not emit
+`partial_post_graduation`; it only emits `bonding_curve` or
+`bonding_curve_pre_graduation`.
+
+## Proposed Backend Architecture
+
+Add files:
+
+```text
+src/endpoints/launchpadCandles.ts
+src/services/LaunchpadChartService.ts
+```
+
+Extend files:
+
+```text
+src/validation/schemas.ts
+src/server.ts
+src/swagger/schemas.ts
+src/endpoints/launchpad.ts or imports next to it
+```
+
+Validation schema:
+
+```ts
+export const LaunchpadCandlesQuerySchema = z.object({
+  chainId: z
+    .string()
+    .optional()
+    .default("4114")
+    .transform(Number)
+    .pipe(ChainIdSchema),
+  interval: z.enum(["1m", "5m", "15m", "1h", "4h", "1d"]).default("5m"),
+  from: z
+    .string()
+    .optional()
+    .transform((v) => (v ? Number(v) : undefined)),
+  to: z
+    .string()
+    .optional()
+    .transform((v) => (v ? Number(v) : undefined)),
+  limit: z
+    .string()
+    .optional()
+    .default("1000")
+    .transform(Number)
+    .pipe(z.number().int().min(1).max(1500)),
+  currency: z.literal("base").default("base"),
+  fill: z.enum(["none", "last"]).optional().default("none"),
+});
+```
+
+Add a token address params schema instead of reusing a pool-specific name:
+
+```ts
+export const LaunchpadTokenAddressParamsSchema = z.object({
+  address: AddressSchema,
+});
+```
+
+Endpoint route:
+
+```ts
+app.get(
+  "/v1/launchpad/token/:address/candles",
+  generalLimiter,
+  validateParams(LaunchpadTokenAddressParamsSchema, logger),
+  validateQuery(LaunchpadCandlesQuerySchema, logger),
+  handleLaunchpadCandles,
+);
+```
+
+Implementation notes:
+
+- Use `getAddress(req.params.address)` for checksum validation.
+- Use `ResponseCache` with a short TTL: 5 to 15 seconds for `1m`/`5m`, 30 to
+  60 seconds for larger intervals.
+- Use GraphQL directly through `PonderClient.query`, not the Ponder REST trade
+  endpoint, because GraphQL supports deterministic `orderBy: "timestamp"` and
+  range filters.
+- For range queries, page Ponder's GraphQL connection locally with `after` and
+  `pageInfo`, using `limit: 1000` per page and a safety cap on total pages.
+- Resolve `from` to the containing bucket start and cap the resolved range by
+  `limit` before querying Ponder, so the first returned bucket is not missing
+  earlier trades from the same interval.
+- Use a cache key that includes `chainId`, token address, interval, range,
+  currency, fill mode, and optional trader marker wallet.
+- Return a 404 only if the token does not exist. Return an empty candle list for
+  known tokens with no trade history. With `fill=last`, seed the chart from the
+  last trade before `from` when one exists.
+- Treat raw Ponder amount fields as strings, validate them during conversion,
+  and convert with `ethers.utils.formatUnits`/`parseFloat` before response-side
+  price and volume math. OHLC and volume fields remain JSON numbers.
+
+## Candle Math
+
+Use helper functions rather than embedding math in the endpoint.
+
+```ts
+function toDecimal(raw: string, decimals: number): number;
+function executionPriceBasePerToken(
+  baseRaw: string,
+  tokenRaw: string,
+): number | null;
+function bucketStart(timestamp: number, intervalSec: number): number;
+function addTradeToBucket(bucket, trade): void;
+```
+
+For bonding curve:
+
+```text
+price = decimal(baseAmount, baseDecimals) / decimal(tokenAmount, tokenDecimals)
+```
+
+For V2 swap records after the indexer is extended:
+
+```text
+if launchpad token is token0 and JUSD is token1:
+  tokenAmount = abs(amount0In - amount0Out)
+  baseAmount = abs(amount1In - amount1Out)
+  reservePrice = reserve1After / reserve0After
+
+if launchpad token is token1 and JUSD is token0:
+  tokenAmount = abs(amount1In - amount1Out)
+  baseAmount = abs(amount0In - amount0Out)
+  reservePrice = reserve0After / reserve1After
+```
+
+For a later USD output:
+
+- JUSD can be treated as USD 1.0 for Launchpad chart display, matching the
+  existing Explore assumptions.
+- If the base asset becomes non-stable later, use `PriceService` and expose
+  `currency=base` as the canonical source.
+
+## Frontend Recommendation
+
+Use `lightweight-charts` for the token chart UI.
+
+Reasons:
+
+- It is purpose-built for financial charts and candlesticks.
+- It supports streaming updates.
+- It is small and open source.
+- It accepts normal OHLC data; no TradingView market-data integration is
+  required.
+
+Frontend should not use the current `/trades` endpoint as the primary chart
+data source. It can use `/trades` for the live trade table. The chart should
+consume `/candles`.
+
+Expected frontend panels per token:
+
+- Candlestick price chart.
+- Volume histogram below the candles.
+- Recent trades table.
+- Current price, 1h/24h change, market cap/FDV, volume, buy/sell counts.
+- Bonding-curve progress before graduation.
+- Graduation marker and V2 pair link after graduation.
+
+Realtime behavior:
+
+- Poll `/candles` every 5 to 10 seconds for the active token page.
+- Poll `/recent-trades` or token `/trades` separately for the trade tape.
+- Later, add a websocket/SSE endpoint only if polling becomes too slow or too
+  expensive.
+
+## Pump.fun-Like Behavior Map
+
+For each token page:
+
+- Before graduation:
+  - Price chart from bonding curve trades.
+  - Progress from `launchpadToken.progress`.
+  - Trade tape from `launchpadTrades`.
+  - Latest price from last candle or on-chain `calculateBuy(1 JUSD)`.
+
+- At graduation:
+  - Add a visual marker on the chart at `graduatedAt`.
+  - Freeze bonding-curve source after that timestamp.
+  - Switch route/trading UI to V2 path.
+
+- After graduation:
+  - Current price from V2 reserves.
+  - Historical candles from indexed V2 swaps once indexer data exists.
+  - Volume bars from V2 stats if swap-level data is not yet indexed.
+
+## Risk Review
+
+High risk: post-graduation historical price is currently under-specified.
+`v2PoolStats` has volume and tx count, not price. Building post-graduation OHLC
+without V2 swap/reserve snapshots would be misleading.
+
+Medium risk: current `launchpadTrade` schema lacks virtual reserves even though
+contract events emit them. Execution-price candles are acceptable for MVP, but
+reserve-price close is more accurate.
+
+Medium risk: using frontend-side trade aggregation will create inconsistent
+charts across clients, especially with pagination, time ranges, and sparse
+trading.
+
+Medium risk: low-volume tokens will have sparse candles. The API should expose
+`fill=none|last` so the frontend can choose between honest gaps and continuous
+visuals. In this branch `fill=last` also queries the last trade before the
+visible range, so quiet tokens can still render a flat continuation instead of
+an empty chart when prior price history exists.
+
+Low risk: API route naming can be changed later, but `candles` is clearer than
+overloading `price-history` because the UI needs OHLCV, not only line data.
+
+## Implementation Phases
+
+Phase 1: API MVP for bonding-curve Launchpad trades
+
+- Add `LaunchpadCandlesQuerySchema`.
+- Add `LaunchpadChartService`.
+- Query `launchpadToken` and `launchpadTrades`.
+- Compute execution-price OHLCV candles.
+- For graduated tokens, keep `source=bonding_curve_pre_graduation`; do not fake
+  V2 candles from `v2PoolStats`.
+- Add route and Swagger docs.
+- Unit test bucket math, decimal conversion, empty token behavior, and invalid
+  query handling.
+
+Phase 2: Better bonding-curve accuracy
+
+- Extend Ponder `launchpadTrade` to store emitted virtual reserves.
+- Add `priceBasis=spot_price` support.
+- Keep `execution_price` available for compatibility.
+
+Phase 3: Graduated V2 historical candles
+
+- Extend Ponder with per-swap V2 data and post-swap reserves for
+  `graduatedV2Pools`.
+- Stitch pre-graduation and post-graduation candles in one response.
+- Add a graduation marker array:
+
+```json
+{
+  "markers": [{ "time": 1771073752, "type": "graduation", "pair": "0x..." }]
+}
+```
+
+Phase 4: UI
+
+- Install `lightweight-charts` in the actual bApp frontend repository.
+- Build a token chart component fed by `/candles`.
+- Add volume series, tooltip/crosshair, timeframe selector, and graduation
+  marker.
+- Use the existing trades endpoint for the live trade table.
+
+## Final Recommendation
+
+Build the backend candle endpoint first. Start with bonding-curve
+execution-price candles because the current Ponder schema already supports it.
+Do not present complete post-graduation OHLC until the indexer stores V2
+swap/reserve snapshots. For the frontend, use TradingView Lightweight Charts
+with API-provided OHLCV and keep raw trades separate.
+
+This gives a Pump.fun-style chart quickly without baking fragile indexer logic
+into the UI, and it leaves a clean path to exact post-graduation charts once the
+Ponder layer is extended.
+
+## Sources
+
+- Local API launchpad proxy endpoints: `src/endpoints/launchpad.ts`.
+- Local route registration: `src/server.ts`.
+- Local launchpad validation schemas: `src/validation/schemas.ts`.
+- Local V3 chart endpoint patterns: `src/endpoints/poolPriceHistory.ts` and
+  `src/endpoints/poolVolumeHistory.ts`.
+- Local Explore launchpad pricing logic: `src/services/ExploreStatsService.ts`.
+- Live Ponder schema and sample data from `https://ponder.juiceswap.com/graphql`
+  and launchpad REST endpoints.
+- Public JuiceSwap docs: `https://docs.juiceswap.com/overview.html`.
+- Public npm package: `@juiceswapxyz/launchpad@3.0.0`.
+- TradingView Lightweight Charts docs: `https://tradingview.github.io/lightweight-charts/`.

--- a/src/endpoints/launchpadCandles.ts
+++ b/src/endpoints/launchpadCandles.ts
@@ -1,0 +1,132 @@
+import { Request, Response } from "express";
+import Logger from "bunyan";
+import { getAddress } from "viem";
+import { ResponseCache } from "../cache/responseCache";
+import {
+  LaunchpadCandlesRequest,
+  LaunchpadChartService,
+  LaunchpadTokenNotFoundError,
+} from "../services/LaunchpadChartService";
+
+const launchpadCandlesCache = new ResponseCache({
+  ttl: 10_000,
+  maxSize: 500,
+  name: "LaunchpadCandlesCache",
+});
+
+/**
+ * @swagger
+ * /v1/launchpad/token/{address}/candles:
+ *   get:
+ *     tags: [Launchpad]
+ *     summary: Get per-token Launchpad OHLCV candles
+ *     description: Builds Pump.fun-style candles from launchpad bonding-curve trades.
+ *     parameters:
+ *       - in: path
+ *         name: address
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Launchpad token contract address
+ *       - in: query
+ *         name: chainId
+ *         schema:
+ *           type: integer
+ *           default: 4114
+ *       - in: query
+ *         name: interval
+ *         schema:
+ *           type: string
+ *           enum: [1m, 5m, 15m, 1h, 4h, 1d]
+ *           default: 5m
+ *       - in: query
+ *         name: from
+ *         schema:
+ *           type: integer
+ *         description: Optional start timestamp in seconds; response range is bucket-aligned and limit-capped
+ *       - in: query
+ *         name: to
+ *         schema:
+ *           type: integer
+ *         description: Optional end timestamp in seconds
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 1000
+ *           maximum: 1500
+ *       - in: query
+ *         name: currency
+ *         schema:
+ *           type: string
+ *           enum: [base]
+ *           default: base
+ *       - in: query
+ *         name: fill
+ *         schema:
+ *           type: string
+ *           enum: [none, last]
+ *           default: none
+ *       - in: query
+ *         name: trader
+ *         schema:
+ *           type: string
+ *         description: Optional wallet address to return per-token user trade markers
+ *     responses:
+ *       200:
+ *         description: Launchpad OHLCV candles for the token
+ *       404:
+ *         description: Launchpad token not found
+ */
+export function createLaunchpadCandlesHandler(logger: Logger) {
+  const service = new LaunchpadChartService(logger);
+
+  return async function handleLaunchpadCandles(
+    req: Request,
+    res: Response,
+  ): Promise<void> {
+    const log = logger.child({ endpoint: "launchpad/token/candles" });
+
+    try {
+      const tokenAddress = getAddress(req.params.address);
+      const query = req.query as unknown as Omit<
+        LaunchpadCandlesRequest,
+        "address"
+      >;
+
+      const cacheKey = JSON.stringify({
+        address: tokenAddress.toLowerCase(),
+        chainId: query.chainId,
+        interval: query.interval,
+        from: query.from,
+        to: query.to,
+        limit: query.limit,
+        currency: query.currency,
+        fill: query.fill,
+        trader: query.trader?.toLowerCase(),
+      });
+
+      const cached = launchpadCandlesCache.get(cacheKey);
+      if (cached) {
+        res.json(cached);
+        return;
+      }
+
+      const response = await service.getCandles({
+        ...query,
+        address: tokenAddress,
+      });
+
+      launchpadCandlesCache.set(cacheKey, response);
+      res.json(response);
+    } catch (error) {
+      if (error instanceof LaunchpadTokenNotFoundError) {
+        res.status(404).json({ error: "Launchpad token not found" });
+        return;
+      }
+
+      log.error({ error }, "Failed to get launchpad token candles");
+      res.status(500).json({ error: "Internal server error" });
+    }
+  };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,6 +27,7 @@ import {
   createLaunchpadStatsHandler,
   createLaunchpadRecentTradesHandler,
 } from "./endpoints/launchpad";
+import { createLaunchpadCandlesHandler } from "./endpoints/launchpadCandles";
 import {
   createUploadImageHandler,
   createUploadMetadataHandler,
@@ -74,6 +75,8 @@ import {
   LaunchpadTokensQuerySchema,
   LaunchpadTradesQuerySchema,
   LaunchpadRecentTradesQuerySchema,
+  LaunchpadCandlesQuerySchema,
+  LaunchpadTokenAddressParamsSchema,
   LightningInvoiceRequestSchema,
   LightningAddressRequestSchema,
   LaunchpadUploadMetadataSchema,
@@ -312,6 +315,7 @@ async function bootstrap() {
   const handleLaunchpadStats = createLaunchpadStatsHandler(logger);
   const handleLaunchpadRecentTrades =
     createLaunchpadRecentTradesHandler(logger);
+  const handleLaunchpadCandles = createLaunchpadCandlesHandler(logger);
   const handleUploadImage = createUploadImageHandler(logger);
   const handleUploadMetadata = createUploadMetadataHandler(logger);
 
@@ -568,6 +572,13 @@ async function bootstrap() {
     generalLimiter,
     validateQuery(LaunchpadTradesQuerySchema, logger),
     handleLaunchpadTokenTrades,
+  );
+  app.get(
+    "/v1/launchpad/token/:address/candles",
+    generalLimiter,
+    validateParams(LaunchpadTokenAddressParamsSchema, logger),
+    validateQuery(LaunchpadCandlesQuerySchema, logger),
+    handleLaunchpadCandles,
   );
   app.get("/v1/launchpad/stats", generalLimiter, handleLaunchpadStats);
   app.get(

--- a/src/services/LaunchpadChartService.ts
+++ b/src/services/LaunchpadChartService.ts
@@ -1,0 +1,753 @@
+import Logger from "bunyan";
+import { ethers } from "ethers";
+import { getPonderClient } from "./PonderClient";
+import type { PonderClient } from "./PonderClient";
+import { getChainContracts } from "../config/contracts";
+
+export const LAUNCHPAD_INTERVAL_SECONDS = {
+  "1m": 60,
+  "5m": 5 * 60,
+  "15m": 15 * 60,
+  "1h": 60 * 60,
+  "4h": 4 * 60 * 60,
+  "1d": 24 * 60 * 60,
+} as const;
+
+export type LaunchpadChartInterval = keyof typeof LAUNCHPAD_INTERVAL_SECONDS;
+export type LaunchpadChartCurrency = "base";
+export type LaunchpadChartFill = "none" | "last";
+export type LaunchpadChartSource =
+  | "bonding_curve"
+  | "bonding_curve_pre_graduation";
+
+export interface LaunchpadCandlesRequest {
+  address: string;
+  chainId: number;
+  interval: LaunchpadChartInterval;
+  limit: number;
+  currency: LaunchpadChartCurrency;
+  fill: LaunchpadChartFill;
+  from?: number;
+  to?: number;
+  trader?: string;
+}
+
+export interface LaunchpadCandle {
+  time: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volumeBase: number;
+  volumeToken: number;
+  tradeCount: number;
+}
+
+export interface LaunchpadUserTradeMarker {
+  time: number;
+  side: "buy" | "sell";
+  price: number;
+  baseAmount: number;
+  tokenAmount: number;
+  txHash: string;
+  blockNumber: number;
+}
+
+interface LaunchpadTokenRecord {
+  address: string;
+  chainId: number;
+  name: string;
+  symbol: string;
+  baseAsset: string;
+  graduated: boolean;
+  canGraduate: boolean;
+  v2Pair: string | null;
+  graduatedAt: string | null;
+  totalBuys: number;
+  totalSells: number;
+  totalVolumeBase: string;
+  lastTradeAt: string | null;
+  progress: number;
+}
+
+export interface LaunchpadTradeRecord {
+  id: string;
+  tokenAddress: string;
+  chainId: number;
+  trader: string;
+  isBuy: boolean;
+  baseAmount: string;
+  tokenAmount: string;
+  timestamp: string;
+  blockNumber: string;
+  txHash: string;
+}
+
+export interface LaunchpadCandlesResponse {
+  token: LaunchpadTokenRecord;
+  quote: {
+    address: string;
+    symbol: string;
+    decimals: number;
+  };
+  range: {
+    from: number;
+    to: number;
+    interval: LaunchpadChartInterval;
+    intervalSeconds: number;
+    limit: number;
+  };
+  source: LaunchpadChartSource;
+  priceBasis: "execution_price";
+  currency: LaunchpadChartCurrency;
+  candles: LaunchpadCandle[];
+  latest: { price: number; timestamp: number } | null;
+  markers: Array<{ time: number; type: "graduation"; pair: string | null }>;
+  userTrades?: LaunchpadUserTradeMarker[];
+}
+
+export class LaunchpadTokenNotFoundError extends Error {
+  constructor(address: string, chainId: number) {
+    super(`Launchpad token not found: ${address} on chain ${chainId}`);
+    this.name = "LaunchpadTokenNotFoundError";
+  }
+}
+
+interface ResolvedRange {
+  from: number;
+  to: number;
+  intervalSeconds: number;
+}
+
+interface CandleAccumulator extends LaunchpadCandle {
+  lastTradeTimestamp: number;
+}
+
+const LAUNCHPAD_TRADE_PAGE_LIMIT = 1000;
+const MAX_LAUNCHPAD_TRADE_PAGES = 500;
+
+interface LaunchpadTradePageInfo {
+  endCursor?: string | null;
+  hasNextPage?: boolean | null;
+}
+
+interface LaunchpadTradesPage {
+  items?: LaunchpadTradeRecord[];
+  pageInfo?: LaunchpadTradePageInfo;
+}
+
+interface LaunchpadTradesPageResult {
+  launchpadTrades?: LaunchpadTradesPage;
+}
+
+export class LaunchpadChartService {
+  private logger: Logger;
+
+  constructor(logger: Logger) {
+    this.logger = logger.child({ service: "LaunchpadChartService" });
+  }
+
+  async getCandles(
+    request: LaunchpadCandlesRequest,
+  ): Promise<LaunchpadCandlesResponse> {
+    const tokenAddress = request.address.toLowerCase();
+    const traderAddress = request.trader?.toLowerCase();
+    const range = resolveLaunchpadChartRange(request);
+    const ponderClient = getPonderClient(this.logger);
+
+    const [token, unsortedTrades, previousTrade] = await Promise.all([
+      this.fetchLaunchpadToken(request.chainId, tokenAddress),
+      fetchLaunchpadTradesForCandles({
+        ponderClient,
+        chainId: request.chainId,
+        tokenAddress,
+        from: range.from,
+        to: range.to,
+      }),
+      request.fill === "last"
+        ? this.fetchLatestLaunchpadTradeBefore(
+            request.chainId,
+            tokenAddress,
+            range.from,
+          )
+        : Promise.resolve(null),
+    ]);
+
+    if (!token) {
+      throw new LaunchpadTokenNotFoundError(request.address, request.chainId);
+    }
+
+    const trades = sortLaunchpadTrades(
+      dedupeLaunchpadTradesById(unsortedTrades),
+    );
+    const previousClose = previousTrade
+      ? executionPriceBasePerToken(
+          previousTrade.baseAmount,
+          previousTrade.tokenAmount,
+        )
+      : null;
+    const tradesForLatest = previousTrade
+      ? sortLaunchpadTrades([previousTrade, ...trades])
+      : trades;
+    const candles = buildLaunchpadCandles({
+      trades,
+      intervalSeconds: range.intervalSeconds,
+      from: range.from,
+      to: range.to,
+      limit: request.limit,
+      fill: request.fill,
+      previousClose: previousClose ?? undefined,
+    });
+    const latest = getLatestTradePrice(tradesForLatest);
+
+    const quote = getLaunchpadQuote(token, request.chainId);
+    const markers = buildGraduationMarkers(token, range.from, range.to);
+    const userTrades = traderAddress
+      ? buildLaunchpadUserTradeMarkers(trades, traderAddress)
+      : undefined;
+
+    return {
+      token,
+      quote,
+      range: {
+        from: range.from,
+        to: range.to,
+        interval: request.interval,
+        intervalSeconds: range.intervalSeconds,
+        limit: request.limit,
+      },
+      source: token.graduated
+        ? "bonding_curve_pre_graduation"
+        : "bonding_curve",
+      priceBasis: "execution_price",
+      currency: request.currency,
+      candles,
+      latest,
+      markers,
+      ...(userTrades ? { userTrades } : {}),
+    };
+  }
+
+  private async fetchLaunchpadToken(
+    chainId: number,
+    address: string,
+  ): Promise<LaunchpadTokenRecord | null> {
+    const ponderClient = getPonderClient(this.logger);
+    const result = await ponderClient.query<{
+      launchpadTokens?: { items?: LaunchpadTokenRecord[] };
+    }>(
+      `
+        query GetLaunchpadTokenForCandles($where: launchpadTokenFilter = {}) {
+          launchpadTokens(where: $where, limit: 1) {
+            items {
+              address
+              chainId
+              name
+              symbol
+              baseAsset
+              graduated
+              canGraduate
+              v2Pair
+              graduatedAt
+              totalBuys
+              totalSells
+              totalVolumeBase
+              lastTradeAt
+              progress
+            }
+          }
+        }
+      `,
+      { where: { chainId, address } },
+    );
+
+    return result.launchpadTokens?.items?.[0] ?? null;
+  }
+
+  private async fetchLatestLaunchpadTradeBefore(
+    chainId: number,
+    tokenAddress: string,
+    timestamp: number,
+  ): Promise<LaunchpadTradeRecord | null> {
+    const ponderClient = getPonderClient(this.logger);
+    const result = await ponderClient.query<{
+      launchpadTrades?: {
+        items?: Array<Pick<LaunchpadTradeRecord, "timestamp">>;
+      };
+    }>(
+      `
+        query GetLaunchpadTradeTimestampBeforeCandles($where: launchpadTradeFilter = {}) {
+          launchpadTrades(where: $where, orderBy: "timestamp", orderDirection: "desc", limit: 1) {
+            items {
+              timestamp
+            }
+          }
+        }
+      `,
+      {
+        where: {
+          chainId,
+          tokenAddress,
+          timestamp_lt: timestamp.toString(),
+        },
+      },
+    );
+
+    const latestTimestamp = result.launchpadTrades?.items?.[0]?.timestamp;
+    if (!latestTimestamp) return null;
+
+    const tiedTrades = await fetchLaunchpadTradePages({
+      ponderClient,
+      where: {
+        chainId,
+        tokenAddress,
+        timestamp: latestTimestamp,
+      },
+      orderBy: "id",
+      orderDirection: "asc",
+    });
+    const sorted = sortLaunchpadTrades(dedupeLaunchpadTradesById(tiedTrades));
+
+    return sorted[sorted.length - 1] ?? null;
+  }
+}
+
+export async function fetchLaunchpadTradesForCandles({
+  ponderClient,
+  chainId,
+  tokenAddress,
+  from,
+  to,
+}: {
+  ponderClient: Pick<PonderClient, "query">;
+  chainId: number;
+  tokenAddress: string;
+  from: number;
+  to: number;
+}): Promise<LaunchpadTradeRecord[]> {
+  return fetchLaunchpadTradePages({
+    ponderClient,
+    where: {
+      tokenAddress,
+      chainId,
+      timestamp_gte: from.toString(),
+      timestamp_lte: to.toString(),
+    },
+    orderBy: "timestamp",
+    orderDirection: "asc",
+  });
+}
+
+async function fetchLaunchpadTradePages({
+  ponderClient,
+  where,
+  orderBy,
+  orderDirection,
+}: {
+  ponderClient: Pick<PonderClient, "query">;
+  where: Record<string, unknown>;
+  orderBy: "timestamp" | "id";
+  orderDirection: "asc" | "desc";
+}): Promise<LaunchpadTradeRecord[]> {
+  const accumulated: LaunchpadTradeRecord[] = [];
+  let after: string | undefined;
+
+  for (let page = 0; page < MAX_LAUNCHPAD_TRADE_PAGES; page++) {
+    const variables: { where: Record<string, unknown>; after?: string } = {
+      where,
+    };
+    if (after) variables.after = after;
+
+    const result = await ponderClient.query<LaunchpadTradesPageResult>(
+      `
+        query GetLaunchpadTradePage($where: launchpadTradeFilter = {}, $after: String) {
+          launchpadTrades(
+            where: $where,
+            orderBy: "${orderBy}",
+            orderDirection: "${orderDirection}",
+            after: $after,
+            limit: ${LAUNCHPAD_TRADE_PAGE_LIMIT}
+          ) {
+            items {
+              id
+              tokenAddress
+              chainId
+              trader
+              isBuy
+              baseAmount
+              tokenAmount
+              timestamp
+              blockNumber
+              txHash
+            }
+            pageInfo {
+              endCursor
+              hasNextPage
+            }
+          }
+        }
+      `,
+      variables,
+    );
+
+    const pageItems = result.launchpadTrades?.items ?? [];
+    accumulated.push(...pageItems);
+
+    const pageInfo = result.launchpadTrades?.pageInfo;
+    if (!pageInfo?.hasNextPage) {
+      return accumulated;
+    }
+
+    if (!pageInfo.endCursor || pageInfo.endCursor === after) {
+      throw new Error("Launchpad trade pagination cursor did not advance");
+    }
+
+    after = pageInfo.endCursor;
+  }
+
+  throw new Error("Launchpad trade pagination exceeded safety page limit");
+}
+
+export function resolveLaunchpadChartRange(
+  request: Pick<LaunchpadCandlesRequest, "interval" | "limit" | "from" | "to">,
+): ResolvedRange {
+  const intervalSeconds = LAUNCHPAD_INTERVAL_SECONDS[request.interval];
+  const now = Math.floor(Date.now() / 1000);
+  const to = request.to ?? now;
+  const lastAllowedBucket = bucketStart(to, intervalSeconds);
+  const earliestAllowedBucket =
+    lastAllowedBucket - intervalSeconds * (request.limit - 1);
+  const requestedFrom = request.from ?? earliestAllowedBucket;
+  const requestedFromBucket = bucketStart(requestedFrom, intervalSeconds);
+  const from = Math.max(requestedFromBucket, earliestAllowedBucket);
+
+  return { from, to, intervalSeconds };
+}
+
+export function buildLaunchpadCandles({
+  trades,
+  intervalSeconds,
+  from,
+  to,
+  limit,
+  fill,
+  previousClose,
+}: {
+  trades: LaunchpadTradeRecord[];
+  intervalSeconds: number;
+  from: number;
+  to: number;
+  limit: number;
+  fill: LaunchpadChartFill;
+  previousClose?: number;
+}): LaunchpadCandle[] {
+  const buckets = new Map<number, CandleAccumulator>();
+  const alignedFrom = bucketStart(from, intervalSeconds);
+
+  for (const trade of sortLaunchpadTrades(dedupeLaunchpadTradesById(trades))) {
+    const timestamp = parseInteger(trade.timestamp);
+    if (timestamp === null || timestamp < alignedFrom || timestamp > to) {
+      continue;
+    }
+
+    const price = executionPriceBasePerToken(
+      trade.baseAmount,
+      trade.tokenAmount,
+    );
+    if (price === null) continue;
+
+    const bucketTime = bucketStart(timestamp, intervalSeconds);
+    const baseAmount = toDecimal(trade.baseAmount, 18);
+    const tokenAmount = toDecimal(trade.tokenAmount, 18);
+    const existing = buckets.get(bucketTime);
+
+    if (!existing) {
+      buckets.set(bucketTime, {
+        time: bucketTime,
+        open: price,
+        high: price,
+        low: price,
+        close: price,
+        volumeBase: baseAmount,
+        volumeToken: tokenAmount,
+        tradeCount: 1,
+        lastTradeTimestamp: timestamp,
+      });
+      continue;
+    }
+
+    existing.high = Math.max(existing.high, price);
+    existing.low = Math.min(existing.low, price);
+    existing.volumeBase += baseAmount;
+    existing.volumeToken += tokenAmount;
+    existing.tradeCount += 1;
+
+    if (timestamp >= existing.lastTradeTimestamp) {
+      existing.close = price;
+      existing.lastTradeTimestamp = timestamp;
+    }
+  }
+
+  const candles = Array.from(buckets.values())
+    .sort((a, b) => a.time - b.time)
+    .map(stripAccumulatorFields);
+
+  const capped = candles.length > limit ? candles.slice(-limit) : candles;
+  return fill === "last"
+    ? fillMissingLaunchpadCandles(
+        capped,
+        intervalSeconds,
+        alignedFrom,
+        to,
+        limit,
+        previousClose,
+      )
+    : capped;
+}
+
+export function buildLaunchpadUserTradeMarkers(
+  trades: LaunchpadTradeRecord[],
+  traderAddress: string,
+): LaunchpadUserTradeMarker[] {
+  const normalizedTrader = traderAddress.toLowerCase();
+  return sortLaunchpadTrades(dedupeLaunchpadTradesById(trades))
+    .filter((trade) => trade.trader.toLowerCase() === normalizedTrader)
+    .flatMap((trade) => {
+      const timestamp = parseInteger(trade.timestamp);
+      const blockNumber = parseInteger(trade.blockNumber);
+      const price = executionPriceBasePerToken(
+        trade.baseAmount,
+        trade.tokenAmount,
+      );
+      if (
+        timestamp === null ||
+        blockNumber === null ||
+        price === null ||
+        !Number.isFinite(price) ||
+        price <= 0
+      ) {
+        return [];
+      }
+
+      const side: "buy" | "sell" = trade.isBuy ? "buy" : "sell";
+      return [
+        {
+          time: timestamp,
+          side,
+          price,
+          baseAmount: toDecimal(trade.baseAmount, 18),
+          tokenAmount: toDecimal(trade.tokenAmount, 18),
+          txHash: trade.txHash,
+          blockNumber,
+        },
+      ];
+    })
+    .sort((a, b) => {
+      const timeDiff = a.time - b.time;
+      if (timeDiff !== 0) return timeDiff;
+
+      const blockDiff = a.blockNumber - b.blockNumber;
+      if (blockDiff !== 0) return blockDiff;
+
+      return a.txHash.localeCompare(b.txHash);
+    });
+}
+
+export function executionPriceBasePerToken(
+  baseAmountRaw: string,
+  tokenAmountRaw: string,
+): number | null {
+  let baseAmount: number;
+  let tokenAmount: number;
+
+  try {
+    baseAmount = toDecimal(baseAmountRaw, 18);
+    tokenAmount = toDecimal(tokenAmountRaw, 18);
+  } catch {
+    return null;
+  }
+
+  if (!Number.isFinite(baseAmount) || baseAmount <= 0) return null;
+  if (!Number.isFinite(tokenAmount) || tokenAmount <= 0) return null;
+  return baseAmount / tokenAmount;
+}
+
+export function toDecimal(raw: string, decimals: number): number {
+  return parseFloat(ethers.utils.formatUnits(raw, decimals));
+}
+
+export function bucketStart(
+  timestamp: number,
+  intervalSeconds: number,
+): number {
+  return Math.floor(timestamp / intervalSeconds) * intervalSeconds;
+}
+
+function fillMissingLaunchpadCandles(
+  candles: LaunchpadCandle[],
+  intervalSeconds: number,
+  from: number,
+  to: number,
+  limit: number,
+  previousClose?: number,
+): LaunchpadCandle[] {
+  const lastAllowedBucket = bucketStart(to, intervalSeconds);
+  const earliestAllowedBucket = Math.max(
+    bucketStart(from, intervalSeconds),
+    lastAllowedBucket - intervalSeconds * (limit - 1),
+  );
+  if (candles.length === 0 && previousClose === undefined) return [];
+
+  const byTime = new Map(candles.map((candle) => [candle.time, candle]));
+  const firstBucket = candles[0]?.time;
+  const start =
+    previousClose === undefined && firstBucket !== undefined
+      ? Math.max(firstBucket, earliestAllowedBucket)
+      : earliestAllowedBucket;
+  const result: LaunchpadCandle[] = [];
+  let close = previousClose ?? candles[0].open;
+
+  for (const candle of candles) {
+    if (candle.time >= start) break;
+    close = candle.close;
+  }
+
+  for (
+    let bucket = start;
+    bucket <= lastAllowedBucket && result.length < limit;
+    bucket += intervalSeconds
+  ) {
+    const existing = byTime.get(bucket);
+    if (existing) {
+      result.push(existing);
+      close = existing.close;
+      continue;
+    }
+
+    result.push({
+      time: bucket,
+      open: close,
+      high: close,
+      low: close,
+      close,
+      volumeBase: 0,
+      volumeToken: 0,
+      tradeCount: 0,
+    });
+  }
+
+  return result;
+}
+
+function sortLaunchpadTrades(
+  trades: LaunchpadTradeRecord[],
+): LaunchpadTradeRecord[] {
+  return [...trades].sort((a, b) => {
+    const timestampDiff = compareNullableNumbers(
+      parseInteger(a.timestamp),
+      parseInteger(b.timestamp),
+    );
+    if (timestampDiff !== 0) return timestampDiff;
+
+    const blockDiff = compareNullableNumbers(
+      parseInteger(a.blockNumber),
+      parseInteger(b.blockNumber),
+    );
+    if (blockDiff !== 0) return blockDiff;
+
+    return a.id.localeCompare(b.id);
+  });
+}
+
+function dedupeLaunchpadTradesById(
+  trades: LaunchpadTradeRecord[],
+): LaunchpadTradeRecord[] {
+  const seen = new Set<string>();
+  const deduped: LaunchpadTradeRecord[] = [];
+
+  for (const trade of trades) {
+    if (seen.has(trade.id)) continue;
+    seen.add(trade.id);
+    deduped.push(trade);
+  }
+
+  return deduped;
+}
+
+function stripAccumulatorFields(candle: CandleAccumulator): LaunchpadCandle {
+  return {
+    time: candle.time,
+    open: candle.open,
+    high: candle.high,
+    low: candle.low,
+    close: candle.close,
+    volumeBase: candle.volumeBase,
+    volumeToken: candle.volumeToken,
+    tradeCount: candle.tradeCount,
+  };
+}
+
+function getLatestTradePrice(
+  trades: LaunchpadTradeRecord[],
+): { price: number; timestamp: number } | null {
+  for (let i = trades.length - 1; i >= 0; i--) {
+    const trade = trades[i];
+    const timestamp = parseInteger(trade.timestamp);
+    if (timestamp === null) continue;
+
+    const price = executionPriceBasePerToken(
+      trade.baseAmount,
+      trade.tokenAmount,
+    );
+    if (price !== null) {
+      return { price, timestamp };
+    }
+  }
+  return null;
+}
+
+function buildGraduationMarkers(
+  token: LaunchpadTokenRecord,
+  from: number,
+  to: number,
+): Array<{ time: number; type: "graduation"; pair: string | null }> {
+  if (!token.graduatedAt) return [];
+
+  const time = parseInteger(token.graduatedAt);
+  if (time === null || time < from || time > to) {
+    return [];
+  }
+
+  return [{ time, type: "graduation", pair: token.v2Pair }];
+}
+
+function parseInteger(value: string): number | null {
+  if (!/^-?\d+$/.test(value)) return null;
+
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function compareNullableNumbers(a: number | null, b: number | null): number {
+  if (a !== null && b !== null) return a - b;
+  if (a === null && b !== null) return 1;
+  if (a !== null && b === null) return -1;
+  return 0;
+}
+
+function getLaunchpadQuote(
+  token: LaunchpadTokenRecord,
+  chainId: number,
+): { address: string; symbol: string; decimals: number } {
+  const contracts = getChainContracts(chainId);
+  const baseAsset = token.baseAsset;
+  const isJusd =
+    contracts?.JUSD &&
+    contracts.JUSD.toLowerCase() === token.baseAsset.toLowerCase();
+
+  return {
+    address: baseAsset,
+    symbol: isJusd ? "JUSD" : "BASE",
+    decimals: 18,
+  };
+}

--- a/src/services/__tests__/LaunchpadChartService.test.ts
+++ b/src/services/__tests__/LaunchpadChartService.test.ts
@@ -1,0 +1,686 @@
+import Logger from "bunyan";
+import {
+  buildLaunchpadCandles,
+  buildLaunchpadUserTradeMarkers,
+  bucketStart,
+  executionPriceBasePerToken,
+  fetchLaunchpadTradesForCandles,
+  LaunchpadChartService,
+  LaunchpadTradeRecord,
+  resolveLaunchpadChartRange,
+} from "../LaunchpadChartService";
+import { getPonderClient } from "../PonderClient";
+import {
+  LaunchpadCandlesQuerySchema,
+  LaunchpadTokenAddressParamsSchema,
+} from "../../validation/schemas";
+
+jest.mock("../PonderClient", () => ({
+  getPonderClient: jest.fn(),
+}));
+
+function trade(overrides: Partial<LaunchpadTradeRecord>): LaunchpadTradeRecord {
+  return {
+    id: "tx-1-0",
+    tokenAddress: "0xtoken",
+    chainId: 4114,
+    trader: "0x1111111111111111111111111111111111111111",
+    isBuy: true,
+    baseAmount: "1000000000000000000",
+    tokenAmount: "1000000000000000000000",
+    timestamp: "300",
+    blockNumber: "10",
+    txHash: "0xhash",
+    ...overrides,
+  };
+}
+
+function createMockLogger(): Logger {
+  const logger = {
+    child: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+  return logger as unknown as Logger;
+}
+
+describe("LaunchpadChartService candle helpers", () => {
+  it("computes execution price in base per token", () => {
+    expect(
+      executionPriceBasePerToken(
+        "1000000000000000000",
+        "250000000000000000000000",
+      ),
+    ).toBe(0.000004);
+  });
+
+  it("builds OHLCV candles per token from launchpad trades", () => {
+    const trades = [
+      trade({
+        id: "a",
+        baseAmount: "1000000000000000000",
+        tokenAmount: "1000000000000000000000",
+        timestamp: "300",
+      }),
+      trade({
+        id: "b",
+        baseAmount: "3000000000000000000",
+        tokenAmount: "1000000000000000000000",
+        timestamp: "320",
+      }),
+      trade({
+        id: "c",
+        isBuy: false,
+        baseAmount: "2000000000000000000",
+        tokenAmount: "1000000000000000000000",
+        timestamp: "610",
+      }),
+    ];
+
+    const candles = buildLaunchpadCandles({
+      trades,
+      intervalSeconds: 300,
+      from: 0,
+      to: 900,
+      limit: 100,
+      fill: "none",
+    });
+
+    expect(candles).toEqual([
+      {
+        time: 300,
+        open: 0.001,
+        high: 0.003,
+        low: 0.001,
+        close: 0.003,
+        volumeBase: 4,
+        volumeToken: 2000,
+        tradeCount: 2,
+      },
+      {
+        time: 600,
+        open: 0.002,
+        high: 0.002,
+        low: 0.002,
+        close: 0.002,
+        volumeBase: 2,
+        volumeToken: 1000,
+        tradeCount: 1,
+      },
+    ]);
+  });
+
+  it("sorts trades before computing candle open and close", () => {
+    const candles = buildLaunchpadCandles({
+      trades: [
+        trade({
+          id: "b",
+          baseAmount: "3000000000000000000",
+          tokenAmount: "1000000000000000000000",
+          timestamp: "320",
+          blockNumber: "11",
+        }),
+        trade({
+          id: "a",
+          baseAmount: "1000000000000000000",
+          tokenAmount: "1000000000000000000000",
+          timestamp: "300",
+          blockNumber: "10",
+        }),
+      ],
+      intervalSeconds: 300,
+      from: 0,
+      to: 600,
+      limit: 100,
+      fill: "none",
+    });
+
+    expect(candles[0]).toMatchObject({
+      time: 300,
+      open: 0.001,
+      close: 0.003,
+    });
+  });
+
+  it("aligns resolved ranges to bucket starts and caps to the requested limit", () => {
+    expect(
+      resolveLaunchpadChartRange({
+        interval: "5m",
+        limit: 3,
+        from: 650,
+        to: 1199,
+      }),
+    ).toEqual({ from: 600, to: 1199, intervalSeconds: 300 });
+
+    expect(
+      resolveLaunchpadChartRange({
+        interval: "5m",
+        limit: 3,
+        from: 0,
+        to: 1199,
+      }),
+    ).toEqual({ from: 300, to: 1199, intervalSeconds: 300 });
+  });
+
+  it("includes the full first bucket when from falls inside the bucket", () => {
+    const candles = buildLaunchpadCandles({
+      trades: [
+        trade({
+          id: "a",
+          baseAmount: "1000000000000000000",
+          tokenAmount: "1000000000000000000000",
+          timestamp: "620",
+        }),
+        trade({
+          id: "b",
+          baseAmount: "2000000000000000000",
+          tokenAmount: "1000000000000000000000",
+          timestamp: "700",
+        }),
+      ],
+      intervalSeconds: 300,
+      from: 650,
+      to: 900,
+      limit: 10,
+      fill: "none",
+    });
+
+    expect(candles).toEqual([
+      {
+        time: 600,
+        open: 0.001,
+        high: 0.002,
+        low: 0.001,
+        close: 0.002,
+        volumeBase: 3,
+        volumeToken: 2000,
+        tradeCount: 2,
+      },
+    ]);
+  });
+
+  it("deduplicates trades by id before counting candle volume", () => {
+    const duplicate = trade({
+      id: "a",
+      baseAmount: "1000000000000000000",
+      tokenAmount: "1000000000000000000000",
+      timestamp: "300",
+    });
+
+    const candles = buildLaunchpadCandles({
+      trades: [duplicate, duplicate],
+      intervalSeconds: 300,
+      from: 0,
+      to: 600,
+      limit: 10,
+      fill: "none",
+    });
+
+    expect(candles).toEqual([
+      {
+        time: 300,
+        open: 0.001,
+        high: 0.001,
+        low: 0.001,
+        close: 0.001,
+        volumeBase: 1,
+        volumeToken: 1000,
+        tradeCount: 1,
+      },
+    ]);
+  });
+
+  it("fills missing buckets with last close without inventing volume", () => {
+    const candles = buildLaunchpadCandles({
+      trades: [
+        trade({
+          id: "a",
+          baseAmount: "1000000000000000000",
+          tokenAmount: "1000000000000000000000",
+          timestamp: "300",
+        }),
+        trade({
+          id: "b",
+          baseAmount: "2000000000000000000",
+          tokenAmount: "1000000000000000000000",
+          timestamp: "900",
+        }),
+      ],
+      intervalSeconds: 300,
+      from: 0,
+      to: 900,
+      limit: 10,
+      fill: "last",
+    });
+
+    expect(candles.map((candle) => candle.time)).toEqual([300, 600, 900]);
+    expect(candles[1]).toMatchObject({
+      open: 0.001,
+      high: 0.001,
+      low: 0.001,
+      close: 0.001,
+      volumeBase: 0,
+      volumeToken: 0,
+      tradeCount: 0,
+    });
+  });
+
+  it("uses the last close before the visible range when filling sparse candles", () => {
+    const candles = buildLaunchpadCandles({
+      trades: [
+        trade({
+          id: "a",
+          baseAmount: "1000000000000000000",
+          tokenAmount: "1000000000000000000000",
+          timestamp: "0",
+        }),
+        trade({
+          id: "b",
+          baseAmount: "2000000000000000000",
+          tokenAmount: "1000000000000000000000",
+          timestamp: "300",
+        }),
+        trade({
+          id: "c",
+          baseAmount: "3000000000000000000",
+          tokenAmount: "1000000000000000000000",
+          timestamp: "1200",
+        }),
+      ],
+      intervalSeconds: 300,
+      from: 0,
+      to: 1200,
+      limit: 3,
+      fill: "last",
+    });
+
+    expect(candles).toEqual([
+      {
+        time: 600,
+        open: 0.002,
+        high: 0.002,
+        low: 0.002,
+        close: 0.002,
+        volumeBase: 0,
+        volumeToken: 0,
+        tradeCount: 0,
+      },
+      {
+        time: 900,
+        open: 0.002,
+        high: 0.002,
+        low: 0.002,
+        close: 0.002,
+        volumeBase: 0,
+        volumeToken: 0,
+        tradeCount: 0,
+      },
+      {
+        time: 1200,
+        open: 0.003,
+        high: 0.003,
+        low: 0.003,
+        close: 0.003,
+        volumeBase: 3,
+        volumeToken: 1000,
+        tradeCount: 1,
+      },
+    ]);
+  });
+
+  it("fills an otherwise empty visible range from a previous close seed", () => {
+    const candles = buildLaunchpadCandles({
+      trades: [],
+      intervalSeconds: 300,
+      from: 600,
+      to: 1200,
+      limit: 3,
+      fill: "last",
+      previousClose: 0.002,
+    });
+
+    expect(candles).toEqual([
+      {
+        time: 600,
+        open: 0.002,
+        high: 0.002,
+        low: 0.002,
+        close: 0.002,
+        volumeBase: 0,
+        volumeToken: 0,
+        tradeCount: 0,
+      },
+      {
+        time: 900,
+        open: 0.002,
+        high: 0.002,
+        low: 0.002,
+        close: 0.002,
+        volumeBase: 0,
+        volumeToken: 0,
+        tradeCount: 0,
+      },
+      {
+        time: 1200,
+        open: 0.002,
+        high: 0.002,
+        low: 0.002,
+        close: 0.002,
+        volumeBase: 0,
+        volumeToken: 0,
+        tradeCount: 0,
+      },
+    ]);
+  });
+
+  it("fills before the first visible trade from a previous close seed", () => {
+    const candles = buildLaunchpadCandles({
+      trades: [
+        trade({
+          id: "a",
+          baseAmount: "3000000000000000000",
+          tokenAmount: "1000000000000000000000",
+          timestamp: "1200",
+        }),
+      ],
+      intervalSeconds: 300,
+      from: 600,
+      to: 1200,
+      limit: 3,
+      fill: "last",
+      previousClose: 0.002,
+    });
+
+    expect(candles).toEqual([
+      {
+        time: 600,
+        open: 0.002,
+        high: 0.002,
+        low: 0.002,
+        close: 0.002,
+        volumeBase: 0,
+        volumeToken: 0,
+        tradeCount: 0,
+      },
+      {
+        time: 900,
+        open: 0.002,
+        high: 0.002,
+        low: 0.002,
+        close: 0.002,
+        volumeBase: 0,
+        volumeToken: 0,
+        tradeCount: 0,
+      },
+      {
+        time: 1200,
+        open: 0.003,
+        high: 0.003,
+        low: 0.003,
+        close: 0.003,
+        volumeBase: 3,
+        volumeToken: 1000,
+        tradeCount: 1,
+      },
+    ]);
+  });
+
+  it("builds per-token user buy/sell markers", () => {
+    const markers = buildLaunchpadUserTradeMarkers(
+      [
+        trade({
+          id: "a",
+          trader: "0x2222222222222222222222222222222222222222",
+          isBuy: true,
+          timestamp: "300",
+          txHash: "0xbuy",
+        }),
+        trade({
+          id: "b",
+          trader: "0x1111111111111111111111111111111111111111",
+          isBuy: false,
+          timestamp: "600",
+          txHash: "0xsell",
+          blockNumber: "42",
+        }),
+      ],
+      "0x1111111111111111111111111111111111111111",
+    );
+
+    expect(markers).toEqual([
+      {
+        time: 600,
+        side: "sell",
+        price: 0.001,
+        baseAmount: 1,
+        tokenAmount: 1000,
+        txHash: "0xsell",
+        blockNumber: 42,
+      },
+    ]);
+  });
+
+  it("skips user trade markers with invalid timestamps, blocks, or amounts", () => {
+    const markers = buildLaunchpadUserTradeMarkers(
+      [
+        trade({
+          id: "valid",
+          timestamp: "300",
+          blockNumber: "10",
+          txHash: "0xvalid",
+        }),
+        trade({
+          id: "bad-timestamp",
+          timestamp: "300abc",
+          blockNumber: "11",
+          txHash: "0xbadtime",
+        }),
+        trade({
+          id: "bad-block",
+          timestamp: "310",
+          blockNumber: "11abc",
+          txHash: "0xbadblock",
+        }),
+        trade({
+          id: "zero-amount",
+          timestamp: "320",
+          blockNumber: "12",
+          tokenAmount: "0",
+          txHash: "0xzero",
+        }),
+      ],
+      "0x1111111111111111111111111111111111111111",
+    );
+
+    expect(markers).toEqual([
+      {
+        time: 300,
+        side: "buy",
+        price: 0.001,
+        baseAmount: 1,
+        tokenAmount: 1000,
+        txHash: "0xvalid",
+        blockNumber: 10,
+      },
+    ]);
+  });
+
+  it("computes deterministic bucket starts", () => {
+    expect(bucketStart(899, 300)).toBe(600);
+    expect(bucketStart(900, 300)).toBe(900);
+  });
+
+  it("does not compute a price for zero-amount trades", () => {
+    expect(
+      executionPriceBasePerToken("0", "1000000000000000000000"),
+    ).toBeNull();
+    expect(executionPriceBasePerToken("1000000000000000000", "0")).toBeNull();
+  });
+});
+
+describe("LaunchpadChartService Ponder pagination", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("uses Ponder cursors so same-timestamp pages beyond 1000 are not skipped", async () => {
+    const firstPage = Array.from({ length: 1000 }, (_, index) =>
+      trade({
+        id: `same-${index.toString().padStart(4, "0")}`,
+        timestamp: "123",
+      }),
+    );
+    const overflowTrade = trade({ id: "same-1000", timestamp: "123" });
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce({
+        launchpadTrades: {
+          items: firstPage,
+          pageInfo: { endCursor: "cursor-1", hasNextPage: true },
+        },
+      })
+      .mockResolvedValueOnce({
+        launchpadTrades: {
+          items: [overflowTrade],
+          pageInfo: { endCursor: "cursor-2", hasNextPage: false },
+        },
+      });
+    const where = {
+      tokenAddress: "0xtoken",
+      chainId: 4114,
+      timestamp_gte: "100",
+      timestamp_lte: "200",
+    };
+
+    const trades = await fetchLaunchpadTradesForCandles({
+      ponderClient: { query },
+      chainId: 4114,
+      tokenAddress: "0xtoken",
+      from: 100,
+      to: 200,
+    });
+
+    expect(trades).toHaveLength(1001);
+    expect(trades[1000]).toBe(overflowTrade);
+    expect(query).toHaveBeenNthCalledWith(1, expect.any(String), { where });
+    expect(query).toHaveBeenNthCalledWith(2, expect.any(String), {
+      where,
+      after: "cursor-1",
+    });
+  });
+
+  it("fetches all trades at the latest previous timestamp before selecting the seed", async () => {
+    const query = jest
+      .fn()
+      .mockResolvedValueOnce({
+        launchpadTrades: {
+          items: [{ timestamp: "90" }],
+        },
+      })
+      .mockResolvedValueOnce({
+        launchpadTrades: {
+          items: [
+            trade({
+              id: "b",
+              timestamp: "90",
+              blockNumber: "12",
+              baseAmount: "2000000000000000000",
+            }),
+            trade({
+              id: "a",
+              timestamp: "90",
+              blockNumber: "10",
+              baseAmount: "1000000000000000000",
+            }),
+            trade({
+              id: "c",
+              timestamp: "90",
+              blockNumber: "12",
+              baseAmount: "3000000000000000000",
+            }),
+          ],
+          pageInfo: { endCursor: "cursor-1", hasNextPage: false },
+        },
+      });
+    (getPonderClient as jest.Mock).mockReturnValue({ query });
+
+    const service = new LaunchpadChartService(createMockLogger());
+    const previousTrade = await (
+      service as unknown as {
+        fetchLatestLaunchpadTradeBefore: (
+          chainId: number,
+          tokenAddress: string,
+          timestamp: number,
+        ) => Promise<LaunchpadTradeRecord | null>;
+      }
+    ).fetchLatestLaunchpadTradeBefore(4114, "0xtoken", 100);
+
+    expect(previousTrade?.id).toBe("c");
+    expect(previousTrade?.baseAmount).toBe("3000000000000000000");
+    expect(query).toHaveBeenNthCalledWith(1, expect.any(String), {
+      where: {
+        chainId: 4114,
+        tokenAddress: "0xtoken",
+        timestamp_lt: "100",
+      },
+    });
+    expect(query).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('orderBy: "id"'),
+      {
+        where: {
+          chainId: 4114,
+          tokenAddress: "0xtoken",
+          timestamp: "90",
+        },
+      },
+    );
+  });
+});
+
+describe("Launchpad candles validation", () => {
+  it("accepts base currency and rejects usd currency", () => {
+    expect(
+      LaunchpadCandlesQuerySchema.parse({ currency: "base" }),
+    ).toMatchObject({
+      chainId: 4114,
+      currency: "base",
+    });
+
+    expect(
+      LaunchpadCandlesQuerySchema.safeParse({ currency: "usd" }).success,
+    ).toBe(false);
+  });
+
+  it("accepts from zero while still rejecting to zero", () => {
+    expect(
+      LaunchpadCandlesQuerySchema.parse({ from: "0", to: "1" }),
+    ).toMatchObject({
+      from: 0,
+      to: 1,
+    });
+
+    expect(LaunchpadCandlesQuerySchema.safeParse({ to: "0" }).success).toBe(
+      false,
+    );
+    expect(
+      LaunchpadCandlesQuerySchema.safeParse({ from: "-1", to: "1" }).success,
+    ).toBe(false);
+  });
+
+  it("rejects invalid ranges, chains, and token addresses", () => {
+    expect(
+      LaunchpadCandlesQuerySchema.safeParse({ from: "20", to: "10" }).success,
+    ).toBe(false);
+    expect(
+      LaunchpadCandlesQuerySchema.safeParse({ chainId: "1" }).success,
+    ).toBe(false);
+    expect(
+      LaunchpadTokenAddressParamsSchema.safeParse({ address: "not-address" })
+        .success,
+    ).toBe(false);
+  });
+});

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -367,6 +367,39 @@ export type LaunchpadRecentTradesQuery = z.infer<
   typeof LaunchpadRecentTradesQuerySchema
 >;
 
+export const LaunchpadTokenAddressParamsSchema = z.object({
+  address: AddressSchema,
+});
+
+function optionalEpochSeconds(min: number) {
+  return z.preprocess(
+    (val) => (val === "" || val === null ? Number.NaN : val),
+    z.coerce.number().int().min(min).optional(),
+  );
+}
+
+export const LaunchpadCandlesQuerySchema = z
+  .object({
+    chainId: z.coerce.number().int().default(4114).pipe(RoutingChainIdSchema),
+    interval: z.enum(["1m", "5m", "15m", "1h", "4h", "1d"]).default("5m"),
+    from: optionalEpochSeconds(0),
+    to: optionalEpochSeconds(1),
+    limit: z.coerce.number().int().min(1).max(1500).default(1000),
+    currency: z.literal("base").default("base"),
+    fill: z.enum(["none", "last"]).optional().default("none"),
+    trader: AddressSchema.optional(),
+  })
+  .refine(
+    (data) =>
+      data.from === undefined || data.to === undefined || data.from < data.to,
+    {
+      message: "from must be less than to",
+      path: ["from"],
+    },
+  );
+
+export type LaunchpadCandlesQuery = z.infer<typeof LaunchpadCandlesQuerySchema>;
+
 // Lightning address validation schema
 export const LightningAddressRequestSchema = z.object({
   lnLikeAddress: z


### PR DESCRIPTION
## Summary
- add `GET /v1/launchpad/token/:address/candles` for Launchpad token OHLCV data
- build interval candles from Ponder launchpad trades with range, limit, fill, and optional trader markers
- return latest execution price, graduation markers, quote metadata, and chart analysis docs

## Validation
- `npm test -- LaunchpadChartService.test.ts`
- `npm run typecheck`
- `npm run lint` (passes with existing warnings)
- `npm run build`
- `npm test`
- local smoke: `GET /v1/launchpad/token/0x1a5d37d3b9783cfeb0b91768f16fa1cfebf4d0bc/candles?...` returned 289 THERESIA candles and a trader sell marker