### PR TITLE
feat(campaign): Juicer NFT campaign backend (/v1/campaigns/juicer/*)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,21 @@ DISCORD_CALLBACK_URL=http://localhost:3000/v1/campaigns/first-squeezer/discord/c
 # IMPORTANT: This address must match CAMPAIGN_SIGNER_ADDRESS in smart-contracts/.env
 CAMPAIGN_SIGNER_PRIVATE_KEY=your_campaign_signer_private_key_here
 
+# Juicer NFT Campaign Configuration
+# Deployed JuicerNFT.sol addresses (per chain). Leave blank until deployed —
+# /nft/signature fails loudly ("NFT claiming not configured") rather than
+# signing against the zero address.
+JUICER_NFT_CONTRACT_MAINNET=
+JUICER_NFT_CONTRACT_TESTNET=
+# Signer private key for Juicer claim signatures. Its address MUST equal the
+# `signer` set in the deployed JuicerNFT contract. Falls back to
+# CAMPAIGN_SIGNER_PRIVATE_KEY if unset (fine for dev; use a dedicated key in prod).
+JUICER_SIGNER_PRIVATE_KEY=
+# Dedicated Discord OAuth callback so the Juicer flow's verification lands on
+# the Juicer campaign record (the shared Discord app otherwise redirects to the
+# First Squeezer callback). Must be registered as a redirect URI in the Discord app.
+JUICER_DISCORD_CALLBACK_URL=http://localhost:3000/v1/campaigns/juicer/discord/callback
+
 # Bridge Ponder APIs (for protocol stats)
 JUICEDOLLAR_PONDER_URL=https://ponder.juicedollar.com
 LDS_PONDER_URL=https://lightning.space/v1/claim

--- a/prisma/migrations/20260605190724_add_juicer_campaign_jp_spend_and_oauth_callback/migration.sql
+++ b/prisma/migrations/20260605190724_add_juicer_campaign_jp_spend_and_oauth_callback/migration.sql
@@ -1,0 +1,44 @@
+-- AlterTable
+ALTER TABLE "DiscordOAuthSession" ADD COLUMN     "callbackUrl" TEXT;
+
+-- CreateTable
+CREATE TABLE "JuicerCampaignUser" (
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "twitterVerifiedAt" TIMESTAMP(3),
+    "twitterUserId" TEXT,
+    "twitterUsername" TEXT,
+    "discordVerifiedAt" TIMESTAMP(3),
+    "discordUserId" TEXT,
+    "discordUsername" TEXT,
+
+    CONSTRAINT "JuicerCampaignUser_pkey" PRIMARY KEY ("userId")
+);
+
+-- CreateTable
+CREATE TABLE "JpSpend" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "walletAddress" TEXT NOT NULL,
+    "chainId" INTEGER NOT NULL,
+    "amount" INTEGER NOT NULL,
+    "reason" TEXT NOT NULL,
+
+    CONSTRAINT "JpSpend_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "JuicerCampaignUser_twitterUserId_idx" ON "JuicerCampaignUser"("twitterUserId");
+
+-- CreateIndex
+CREATE INDEX "JuicerCampaignUser_discordUserId_idx" ON "JuicerCampaignUser"("discordUserId");
+
+-- CreateIndex
+CREATE INDEX "JpSpend_walletAddress_idx" ON "JpSpend"("walletAddress");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "JpSpend_walletAddress_chainId_reason_key" ON "JpSpend"("walletAddress", "chainId", "reason");
+
+-- AddForeignKey
+ALTER TABLE "JuicerCampaignUser" ADD CONSTRAINT "JuicerCampaignUser_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,7 @@ model User {
 
   // Relations
   ogCampaign      OgCampaignUser?
+  juicerCampaign  JuicerCampaignUser?
 
   @@index([address])
   @@index([ipAddressHash])
@@ -47,6 +48,46 @@ model OgCampaignUser {
   @@index([discordUserId])
 }
 
+// Juicer NFT campaign participation tracking — social verification state
+// for the "Juicer" loyalty drop. Deliberately separate from OgCampaignUser
+// (First Squeezer) so the two campaigns' verification states never bleed
+// into each other.
+model JuicerCampaignUser {
+  userId            String    @id
+  createdAt         DateTime  @default(now())
+  updatedAt         DateTime  @updatedAt
+  user              User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  // Social verification - Twitter and Discord account linking
+  twitterVerifiedAt DateTime?
+  twitterUserId     String?
+  twitterUsername   String?
+  discordVerifiedAt DateTime?
+  discordUserId     String?
+  discordUsername   String?
+
+  @@index([twitterUserId])
+  @@index([discordUserId])
+}
+
+// Juice Points spend ledger. JP totals are computed on-the-fly from on-chain
+// data by the Ponder indexer (append-only, earn side); this table is the
+// authoritative off-chain SPEND side: availableJp = ponder total - SUM(amount).
+// The (walletAddress, chainId, reason) unique constraint makes spends
+// idempotent — a retried POST /spend finds the existing row instead of
+// deducting twice.
+model JpSpend {
+  id            String   @id @default(uuid())
+  createdAt     DateTime @default(now())
+  walletAddress String   // lowercase 0x address
+  chainId       Int
+  amount        Int      // JP deducted (positive)
+  reason        String   // e.g. "juicer_nft"
+
+  @@unique([walletAddress, chainId, reason])
+  @@index([walletAddress])
+}
+
 // Twitter OAuth session storage (replaces in-memory storage)
 // Sessions expire after 10 minutes for security
 model TwitterOAuthSession {
@@ -68,6 +109,10 @@ model DiscordOAuthSession {
   id            String   @id @default(uuid())
   state         String   @unique
   walletAddress String
+  // Optional per-flow OAuth redirect URI. When set (e.g. the Juicer campaign
+  // callback), it is used in BOTH the authorize step and the token exchange so
+  // Discord's redirect_uri match check passes. Null = use the service default.
+  callbackUrl   String?
   createdAt     DateTime @default(now())
   expiresAt     DateTime
 

--- a/src/endpoints/__tests__/juicerCampaign.test.ts
+++ b/src/endpoints/__tests__/juicerCampaign.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Juicer NFT claim signature — contract compatibility tests.
+ *
+ * JuicerNFT.sol verifies:
+ *   bytes32 messageHash = keccak256(abi.encodePacked(address(this), block.chainid, msg.sender));
+ *   address recovered = messageHash.toEthSignedMessageHash().recover(signature);
+ *   recovered == signer
+ *
+ * These tests re-derive the contract side with ethers primitives and assert
+ * the backend helper produces a signature the contract would accept — the
+ * single highest-risk invariant of the claim flow (a mismatch bricks every
+ * claim with InvalidSignature, discoverable only on-chain).
+ */
+
+import { ethers } from "ethers";
+import { buildJuicerClaimSignature } from "../juicerCampaign";
+
+// Deterministic test-only key (hardhat account #0 — never used in prod).
+const TEST_PRIVATE_KEY =
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+const TEST_SIGNER_ADDRESS = new ethers.Wallet(TEST_PRIVATE_KEY).address;
+
+const CONTRACT = "0x428B878cB6383216AaDc4e8495037E8d31612621";
+const CHAIN_ID = 4114;
+const WALLET = "0x2f0cc51c02e5d4ec68bc155728798969d5c0f714"; // lowercase on purpose
+
+describe("buildJuicerClaimSignature", () => {
+  it("recovers to the signer for the contract's exact message hash", async () => {
+    const signature = await buildJuicerClaimSignature(
+      TEST_PRIVATE_KEY,
+      CONTRACT,
+      CHAIN_ID,
+      WALLET,
+    );
+
+    // Contract side: keccak256(abi.encodePacked(contract, chainid, wallet)),
+    // then EIP-191 ("\x19Ethereum Signed Message:\n32") before recover.
+    const messageHash = ethers.utils.solidityKeccak256(
+      ["address", "uint256", "address"],
+      [CONTRACT, CHAIN_ID, WALLET],
+    );
+    const recovered = ethers.utils.verifyMessage(
+      ethers.utils.arrayify(messageHash),
+      signature,
+    );
+
+    expect(recovered).toBe(TEST_SIGNER_ADDRESS);
+  });
+
+  it("binds the signature to wallet, contract and chain (no cross-use)", async () => {
+    const signature = await buildJuicerClaimSignature(
+      TEST_PRIVATE_KEY,
+      CONTRACT,
+      CHAIN_ID,
+      WALLET,
+    );
+
+    const recoverFor = (
+      contract: string,
+      chainId: number,
+      wallet: string,
+    ): string => {
+      const hash = ethers.utils.solidityKeccak256(
+        ["address", "uint256", "address"],
+        [contract, chainId, wallet],
+      );
+      return ethers.utils.verifyMessage(ethers.utils.arrayify(hash), signature);
+    };
+
+    // A different wallet, contract, or chain must NOT recover to the signer —
+    // otherwise one issued signature would mint for arbitrary callers.
+    const otherWallet = "0x1111111111111111111111111111111111111111";
+    const otherContract = "0x2222222222222222222222222222222222222222";
+    expect(recoverFor(CONTRACT, CHAIN_ID, otherWallet)).not.toBe(
+      TEST_SIGNER_ADDRESS,
+    );
+    expect(recoverFor(otherContract, CHAIN_ID, WALLET)).not.toBe(
+      TEST_SIGNER_ADDRESS,
+    );
+    expect(recoverFor(CONTRACT, 5115, WALLET)).not.toBe(TEST_SIGNER_ADDRESS);
+  });
+
+  it("is case-insensitive over the wallet address (checksum == lowercase)", async () => {
+    const sigLower = await buildJuicerClaimSignature(
+      TEST_PRIVATE_KEY,
+      CONTRACT,
+      CHAIN_ID,
+      WALLET.toLowerCase(),
+    );
+    const sigChecksum = await buildJuicerClaimSignature(
+      TEST_PRIVATE_KEY,
+      CONTRACT,
+      CHAIN_ID,
+      ethers.utils.getAddress(WALLET),
+    );
+    // solidityKeccak256 encodes the address as 20 raw bytes, so the textual
+    // casing of the input must not change the signature.
+    expect(sigLower).toBe(sigChecksum);
+  });
+});

--- a/src/endpoints/juicerCampaign.ts
+++ b/src/endpoints/juicerCampaign.ts
@@ -1,0 +1,839 @@
+import { Request, Response } from "express";
+import Logger from "bunyan";
+import { ethers } from "ethers";
+import { getDiscordOAuthService } from "../services/DiscordOAuthService";
+import { getPonderClient } from "../services/PonderClient";
+import { prisma } from "../db/prisma";
+import {
+  getJuicerNftContract,
+  JUICER_CAMPAIGN_CHAIN_ID,
+  JUICER_JP_COST,
+  JUICER_SPEND_REASON,
+} from "../lib/constants/campaigns";
+
+/**
+ * Juicer NFT Campaign endpoints.
+ *
+ * Flow (mirrors apps/web/src/services/juicerCampaign in the frontend):
+ *   1. POST /spend                 — trade JUICER_JP_COST JP for the claim right
+ *   2. POST /twitter/mark-followed — mark the X follow (honor system, like the
+ *                                    First Squeezer mark-followed step)
+ *   3. GET  /discord/start|callback — Discord OAuth; requires the Juicer role
+ *   4. GET  /nft/signature         — backend-signed claim() payload, only once
+ *                                    every condition is satisfied
+ *   GET /progress                  — composed read model for all of the above
+ *
+ * JP economics: the EARN side lives in the Ponder indexer (on-chain derived,
+ * append-only; `GET /points/:address`). The SPEND side is the JpSpend ledger
+ * here. availableJp = ponder total − SUM(JpSpend.amount). Spends are
+ * idempotent via the (walletAddress, chainId, reason) unique constraint.
+ */
+
+const ADDRESS_RE = /^0x[a-fA-F0-9]{40}$/;
+
+/**
+ * Build the EIP-191 claim signature consumed by JuicerNFT.claim(signature).
+ * Must stay byte-compatible with the contract, which recovers:
+ *   keccak256(abi.encodePacked(address(this), block.chainid, msg.sender))
+ *     .toEthSignedMessageHash()
+ *     .recover(signature) == signer
+ * `signMessage(arrayify(hash))` applies the same EIP-191 prefix as
+ * toEthSignedMessageHash, so the recovered address equals the signer.
+ */
+export async function buildJuicerClaimSignature(
+  signerPrivateKey: string,
+  contractAddress: string,
+  chainId: number,
+  walletAddress: string,
+): Promise<string> {
+  const signer = new ethers.Wallet(signerPrivateKey);
+  const messageHash = ethers.utils.solidityKeccak256(
+    ["address", "uint256", "address"],
+    [contractAddress, chainId, walletAddress],
+  );
+  return signer.signMessage(ethers.utils.arrayify(messageHash));
+}
+
+interface PonderPointsBreakdown {
+  total: number;
+  swaps: { count: number; points: number };
+  liquidity: {
+    days: number;
+    points: number;
+    currentUsdValue: number;
+    meetsMinimum: boolean;
+  };
+  bonuses: {
+    memeTokenCreated: boolean;
+    memeTokenPoints: number;
+    memeTokenGraduated: boolean;
+    memeTokenGraduatedPoints: number;
+    points: number;
+  };
+}
+
+/**
+ * Earned JP for a wallet, straight from the Ponder points engine.
+ * Throws on indexer failure — callers decide whether to fail open (progress
+ * display) or closed (spend / signature gates MUST fail closed).
+ */
+async function fetchEarnedPoints(
+  log: Logger,
+  walletAddress: string,
+): Promise<PonderPointsBreakdown> {
+  const ponderClient = getPonderClient(log);
+  const response = await ponderClient.get(`/points/${walletAddress}`);
+  return response.data as PonderPointsBreakdown;
+}
+
+/** Sum of all JP this wallet has spent on the campaign chain. */
+async function fetchSpentJp(walletAddress: string): Promise<number> {
+  const agg = await prisma.jpSpend.aggregate({
+    where: {
+      walletAddress: walletAddress.toLowerCase(),
+      chainId: JUICER_CAMPAIGN_CHAIN_ID,
+    },
+    _sum: { amount: true },
+  });
+  return agg._sum.amount ?? 0;
+}
+
+/** The wallet's Juicer spend row, if the 5,000 JP trade already happened. */
+async function fetchJuicerSpend(walletAddress: string) {
+  return prisma.jpSpend.findUnique({
+    where: {
+      walletAddress_chainId_reason: {
+        walletAddress: walletAddress.toLowerCase(),
+        chainId: JUICER_CAMPAIGN_CHAIN_ID,
+        reason: JUICER_SPEND_REASON,
+      },
+    },
+  });
+}
+
+/**
+ * On-chain hasClaimed() for the Juicer NFT. Returns null when the contract is
+ * not configured/deployed yet or the RPC fails — callers must treat null as
+ * "unknown" (progress shows false; the signature path re-checks and the
+ * contract itself is the final double-claim guard).
+ */
+async function fetchNftMinted(
+  log: Logger,
+  walletAddress: string,
+): Promise<boolean | null> {
+  const contractAddress = getJuicerNftContract(JUICER_CAMPAIGN_CHAIN_ID);
+  const rpcUrl = process.env.CITREA_4114_RPC_URL;
+  if (!contractAddress || !rpcUrl) {
+    return null;
+  }
+  try {
+    const provider = new ethers.providers.JsonRpcProvider(rpcUrl);
+    const contract = new ethers.Contract(
+      contractAddress,
+      ["function hasClaimed(address) view returns (bool)"],
+      provider,
+    );
+    return await contract.hasClaimed(walletAddress);
+  } catch (error: any) {
+    log.warn(
+      { error: error.message, walletAddress },
+      "Juicer hasClaimed lookup failed",
+    );
+    return null;
+  }
+}
+
+/**
+ * @swagger
+ * /v1/campaigns/juicer/progress:
+ *   get:
+ *     tags: [Campaign]
+ *     summary: Full Juicer campaign progress for a wallet
+ *     description: >
+ *       Composes the Ponder-earned JP total, the JpSpend ledger, the social
+ *       verification state and the on-chain claim state into the read model
+ *       the Juicer page renders.
+ *     parameters:
+ *       - in: query
+ *         name: walletAddress
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: chainId
+ *         required: false
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 walletAddress: { type: string }
+ *                 chainId: { type: integer }
+ *                 availableJp: { type: number }
+ *                 totalEarnedJp: { type: number }
+ *                 spentJp: { type: number }
+ *                 cost: { type: number }
+ *                 jpSpent: { type: boolean }
+ *                 memeTokenCreated: { type: boolean }
+ *                 twitterVerified: { type: boolean }
+ *                 discordVerified: { type: boolean }
+ *                 isEligibleForNFT: { type: boolean }
+ *                 nftMinted: { type: boolean }
+ *       default:
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+export function createJuicerProgressHandler(logger: Logger) {
+  return async function handleJuicerProgress(
+    req: Request,
+    res: Response,
+  ): Promise<void> {
+    const log = logger.child({ endpoint: "juicer-progress" });
+
+    try {
+      const walletAddress = req.query.walletAddress as string;
+      if (!walletAddress || !ADDRESS_RE.test(walletAddress)) {
+        res.status(400).json({ message: "Invalid wallet address" });
+        return;
+      }
+      const normalizedAddress = walletAddress.toLowerCase();
+
+      // Earned side from Ponder. Progress is a read model, so a down indexer
+      // degrades to zeros instead of breaking the page.
+      let breakdown: PonderPointsBreakdown | null = null;
+      try {
+        breakdown = await fetchEarnedPoints(log, normalizedAddress);
+      } catch (error: any) {
+        log.warn(
+          { error: error.message, walletAddress: normalizedAddress },
+          "Ponder points lookup failed; rendering zero-earned progress",
+        );
+      }
+      const totalEarnedJp = breakdown?.total ?? 0;
+      const memeTokenCreated = breakdown?.bonuses?.memeTokenCreated ?? false;
+
+      // Spend side from the ledger.
+      const [spentJp, juicerSpend] = await Promise.all([
+        fetchSpentJp(normalizedAddress),
+        fetchJuicerSpend(normalizedAddress),
+      ]);
+      const availableJp = Math.max(0, totalEarnedJp - spentJp);
+      const jpSpent = !!juicerSpend;
+
+      // Social verification state.
+      const user = await prisma.user.findUnique({
+        where: { address: normalizedAddress },
+        include: { juicerCampaign: true },
+      });
+      const campaign = user?.juicerCampaign ?? null;
+      const twitterVerified = !!campaign?.twitterVerifiedAt;
+      const discordVerified = !!campaign?.discordVerifiedAt;
+
+      // On-chain claim state (null = unknown -> render as not minted).
+      const nftMinted =
+        (await fetchNftMinted(log, normalizedAddress)) ?? false;
+
+      const isEligibleForNFT =
+        jpSpent &&
+        memeTokenCreated &&
+        twitterVerified &&
+        discordVerified &&
+        !nftMinted;
+
+      res.status(200).json({
+        walletAddress: normalizedAddress,
+        chainId: JUICER_CAMPAIGN_CHAIN_ID,
+        availableJp,
+        totalEarnedJp,
+        spentJp,
+        cost: JUICER_JP_COST,
+        jpSpent,
+        memeTokenCreated,
+        memeTokenCreatedAt: null,
+        twitterVerified,
+        twitterVerifiedAt: campaign?.twitterVerifiedAt?.toISOString() ?? null,
+        discordVerified,
+        discordVerifiedAt: campaign?.discordVerifiedAt?.toISOString() ?? null,
+        isEligibleForNFT,
+        nftMinted,
+      });
+    } catch (error: any) {
+      log.error(
+        { error: error.message, stack: error.stack },
+        "Error in handleJuicerProgress",
+      );
+      res.status(500).json({ message: "Failed to load Juicer progress" });
+    }
+  };
+}
+
+/**
+ * @swagger
+ * /v1/campaigns/juicer/spend:
+ *   post:
+ *     tags: [Campaign]
+ *     summary: Trade 5,000 JP for the right to claim the Juicer NFT
+ *     description: >
+ *       Atomic and idempotent. The (walletAddress, chainId, reason) unique
+ *       constraint guarantees a retried POST returns the original spend record
+ *       without deducting twice. Fails closed if the Ponder indexer cannot be
+ *       reached (the earned balance can't be verified).
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               walletAddress: { type: string }
+ *               chainId: { type: integer }
+ *     responses:
+ *       200:
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 spentJp: { type: number }
+ *                 remainingJp: { type: number }
+ *       default:
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+export function createJuicerSpendHandler(logger: Logger) {
+  return async function handleJuicerSpend(
+    req: Request,
+    res: Response,
+  ): Promise<void> {
+    const log = logger.child({ endpoint: "juicer-spend" });
+
+    try {
+      const walletAddress = req.body?.walletAddress as string;
+      if (!walletAddress || !ADDRESS_RE.test(walletAddress)) {
+        res.status(400).json({ message: "Invalid wallet address" });
+        return;
+      }
+      const normalizedAddress = walletAddress.toLowerCase();
+
+      // Idempotency fast path: spend already recorded.
+      const existing = await fetchJuicerSpend(normalizedAddress);
+      if (existing) {
+        const spentJp = await fetchSpentJp(normalizedAddress);
+        let remainingJp = 0;
+        try {
+          const breakdown = await fetchEarnedPoints(log, normalizedAddress);
+          remainingJp = Math.max(0, breakdown.total - spentJp);
+        } catch {
+          // earned lookup is non-essential on the idempotent replay
+        }
+        res.status(200).json({ spentJp, remainingJp });
+        return;
+      }
+
+      // Balance gate — MUST fail closed when the earn side is unreadable.
+      let totalEarnedJp: number;
+      try {
+        const breakdown = await fetchEarnedPoints(log, normalizedAddress);
+        totalEarnedJp = breakdown.total;
+      } catch (error: any) {
+        log.error(
+          { error: error.message, walletAddress: normalizedAddress },
+          "Ponder unavailable during spend — failing closed",
+        );
+        res
+          .status(503)
+          .json({ message: "Points service unavailable; please retry" });
+        return;
+      }
+
+      const alreadySpent = await fetchSpentJp(normalizedAddress);
+      const availableJp = totalEarnedJp - alreadySpent;
+      if (availableJp < JUICER_JP_COST) {
+        res.status(403).json({
+          message: `Insufficient Juice Points: ${availableJp} available, ${JUICER_JP_COST} required`,
+          availableJp,
+          required: JUICER_JP_COST,
+        });
+        return;
+      }
+
+      // Record the spend. A concurrent duplicate insert loses on the unique
+      // constraint (P2002) and is treated as the idempotent replay.
+      try {
+        await prisma.jpSpend.create({
+          data: {
+            walletAddress: normalizedAddress,
+            chainId: JUICER_CAMPAIGN_CHAIN_ID,
+            amount: JUICER_JP_COST,
+            reason: JUICER_SPEND_REASON,
+          },
+        });
+      } catch (error: any) {
+        if (error?.code !== "P2002") {
+          throw error;
+        }
+        log.info(
+          { walletAddress: normalizedAddress },
+          "Concurrent juicer spend deduped by unique constraint",
+        );
+      }
+
+      const spentJp = await fetchSpentJp(normalizedAddress);
+      const remainingJp = Math.max(0, totalEarnedJp - spentJp);
+
+      log.info(
+        { walletAddress: normalizedAddress, spentJp, remainingJp },
+        "Juicer JP spend recorded",
+      );
+      res.status(200).json({ spentJp, remainingJp });
+    } catch (error: any) {
+      log.error(
+        { error: error.message, stack: error.stack },
+        "Error in handleJuicerSpend",
+      );
+      res.status(500).json({ message: "Failed to spend Juice Points" });
+    }
+  };
+}
+
+/**
+ * @swagger
+ * /v1/campaigns/juicer/twitter/mark-followed:
+ *   post:
+ *     tags: [Campaign]
+ *     summary: Mark a wallet as following @JuiceSwap_com (honor system)
+ *     description: >
+ *       Sets `twitterVerifiedAt` on the Juicer campaign record. Honor-system,
+ *       mirroring the First Squeezer mark-followed step.
+ *     parameters:
+ *       - in: query
+ *         name: walletAddress
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success: { type: boolean }
+ *                 verifiedAt: { type: string, format: date-time }
+ *       default:
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+export function createJuicerTwitterMarkFollowedHandler(logger: Logger) {
+  return async function handleJuicerTwitterMarkFollowed(
+    req: Request,
+    res: Response,
+  ): Promise<void> {
+    const log = logger.child({ endpoint: "juicer-twitter-mark-followed" });
+
+    try {
+      const walletAddress = req.query.walletAddress as string;
+      if (!walletAddress || !ADDRESS_RE.test(walletAddress)) {
+        res.status(400).json({ message: "Invalid wallet address" });
+        return;
+      }
+      const normalizedAddress = walletAddress.toLowerCase();
+
+      let user = await prisma.user.findUnique({
+        where: { address: normalizedAddress },
+      });
+      if (!user) {
+        user = await prisma.user.create({
+          data: { address: normalizedAddress },
+        });
+      }
+
+      const verifiedAt = new Date();
+      await prisma.juicerCampaignUser.upsert({
+        where: { userId: user.id },
+        update: { twitterVerifiedAt: verifiedAt },
+        create: { userId: user.id, twitterVerifiedAt: verifiedAt },
+      });
+
+      log.info(
+        { walletAddress: normalizedAddress },
+        "Juicer Twitter follow marked (honor system)",
+      );
+      res
+        .status(200)
+        .json({ success: true, verifiedAt: verifiedAt.toISOString() });
+    } catch (error: any) {
+      log.error(
+        { error: error.message, stack: error.stack },
+        "Error in handleJuicerTwitterMarkFollowed",
+      );
+      res.status(500).json({ message: "Failed to mark Twitter follow" });
+    }
+  };
+}
+
+/**
+ * @swagger
+ * /v1/campaigns/juicer/discord/start:
+ *   get:
+ *     tags: [Campaign]
+ *     summary: Start Discord OAuth flow for the Juicer campaign
+ *     parameters:
+ *       - in: query
+ *         name: walletAddress
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 authUrl: { type: string }
+ *                 state: { type: string }
+ *       default:
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+export function createJuicerDiscordStartHandler(logger: Logger) {
+  return async function handleJuicerDiscordStart(
+    req: Request,
+    res: Response,
+  ): Promise<void> {
+    const log = logger.child({ endpoint: "juicer-discord-start" });
+
+    try {
+      const walletAddress = req.query.walletAddress as string;
+      if (!walletAddress || !ADDRESS_RE.test(walletAddress)) {
+        res.status(400).json({ message: "Invalid wallet address" });
+        return;
+      }
+      const normalizedAddress = walletAddress.toLowerCase();
+
+      // The shared Discord app defaults to the First Squeezer callback; the
+      // Juicer flow uses its own callback (threaded through the OAuth session
+      // so the token exchange repeats the same redirect_uri) so the
+      // verification lands on the Juicer campaign record.
+      const discordService = getDiscordOAuthService();
+      const { authUrl, state } = await discordService.generateAuthUrl(
+        normalizedAddress,
+        process.env.JUICER_DISCORD_CALLBACK_URL,
+      );
+
+      res.status(200).json({ authUrl, state });
+    } catch (error: any) {
+      log.error(
+        { error: error.message, stack: error.stack },
+        "Error in handleJuicerDiscordStart",
+      );
+      res.status(500).json({
+        message: "Failed to generate OAuth URL",
+        detail: error.message,
+      });
+    }
+  };
+}
+
+/**
+ * @swagger
+ * /v1/campaigns/juicer/discord/callback:
+ *   get:
+ *     tags: [Campaign]
+ *     summary: Discord OAuth callback for the Juicer campaign (redirects to frontend)
+ *     parameters:
+ *       - in: query
+ *         name: code
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: state
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       302:
+ *         description: Redirects to frontend
+ */
+export function createJuicerDiscordCallbackHandler(logger: Logger) {
+  return async function handleJuicerDiscordCallback(
+    req: Request,
+    res: Response,
+  ): Promise<void> {
+    const log = logger.child({ endpoint: "juicer-discord-callback" });
+    const frontendUrl = process.env.FRONTEND_URL || "http://localhost:3001";
+
+    try {
+      const code = req.query.code as string;
+      const state = req.query.state as string;
+
+      if (!code || !state) {
+        log.warn("Missing code or state parameter");
+        res.redirect(
+          `${frontendUrl}/oauth-callback?discord=error&message=missing_params`,
+        );
+        return;
+      }
+
+      const discordService = getDiscordOAuthService();
+      const { walletAddress, discordUser, hasJuicerRole } =
+        await discordService.completeOAuthFlow(code, state);
+
+      if (
+        !discordUser.id ||
+        typeof discordUser.id !== "string" ||
+        discordUser.id.trim() === ""
+      ) {
+        log.error(
+          { walletAddress, discordUser },
+          "Discord OAuth returned user without valid ID",
+        );
+        res.redirect(
+          `${frontendUrl}/oauth-callback?discord=error&message=${encodeURIComponent("Invalid Discord response - missing user ID")}`,
+        );
+        return;
+      }
+
+      if (!hasJuicerRole) {
+        log.warn(
+          { walletAddress, discordUsername: discordUser.username },
+          "User does not have the Juicer role in JuiceSwap Discord",
+        );
+        res.redirect(
+          `${frontendUrl}/oauth-callback?discord=error&message=${encodeURIComponent("Your Discord account must have the Juicer role in the JuiceSwap server")}`,
+        );
+        return;
+      }
+
+      let user = await prisma.user.findUnique({
+        where: { address: walletAddress },
+      });
+      if (!user) {
+        user = await prisma.user.create({ data: { address: walletAddress } });
+      }
+
+      // One Discord account, one wallet — same anti-sybil rule as First
+      // Squeezer, scoped to the Juicer campaign table.
+      const existingDiscordLink = await prisma.juicerCampaignUser.findFirst({
+        where: {
+          discordUserId: discordUser.id,
+          userId: { not: user.id },
+        },
+      });
+      if (existingDiscordLink) {
+        log.warn(
+          {
+            walletAddress,
+            discordUserId: discordUser.id,
+            existingUserId: existingDiscordLink.userId,
+          },
+          "Discord account already linked to different wallet (juicer)",
+        );
+        res.redirect(
+          `${frontendUrl}/oauth-callback?discord=error&message=${encodeURIComponent("This Discord account is already linked to another wallet")}`,
+        );
+        return;
+      }
+
+      const username =
+        discordUser.discriminator && discordUser.discriminator !== "0"
+          ? `${discordUser.username}#${discordUser.discriminator}`
+          : discordUser.username;
+
+      await prisma.juicerCampaignUser.upsert({
+        where: { userId: user.id },
+        update: {
+          discordVerifiedAt: new Date(),
+          discordUserId: discordUser.id,
+          discordUsername: username,
+        },
+        create: {
+          userId: user.id,
+          discordVerifiedAt: new Date(),
+          discordUserId: discordUser.id,
+          discordUsername: username,
+        },
+      });
+
+      log.info(
+        { walletAddress, discordUsername: username },
+        "Juicer Discord account linked successfully",
+      );
+      res.redirect(
+        `${frontendUrl}/oauth-callback?discord=success&username=${encodeURIComponent(username)}`,
+      );
+    } catch (error: any) {
+      log.error(
+        { error: error.message, stack: error.stack },
+        "Error in handleJuicerDiscordCallback",
+      );
+      res.redirect(
+        `${frontendUrl}/oauth-callback?discord=error&message=${encodeURIComponent(error.message || "unknown_error")}`,
+      );
+    }
+  };
+}
+
+/**
+ * @swagger
+ * /v1/campaigns/juicer/nft/signature:
+ *   get:
+ *     tags: [Campaign]
+ *     summary: Get the Juicer NFT claim signature
+ *     description: |
+ *       Issues the signature for JuicerNFT.claim(). Every gate fails CLOSED:
+ *       the JP spend must be on the ledger, the meme token must exist on the
+ *       campaign chain (verified against Ponder), Twitter and Discord must be
+ *       verified, and the wallet must not have claimed yet.
+ *     parameters:
+ *       - in: query
+ *         name: walletAddress
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 signature: { type: string }
+ *                 contractAddress: { type: string }
+ *       default:
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+export function createJuicerNftSignatureHandler(logger: Logger) {
+  return async function handleJuicerNftSignature(
+    req: Request,
+    res: Response,
+  ): Promise<void> {
+    const log = logger.child({ endpoint: "juicer-nft-signature" });
+
+    try {
+      const walletAddress = req.query.walletAddress as string;
+      if (!walletAddress || !ADDRESS_RE.test(walletAddress)) {
+        res.status(400).json({ message: "Invalid wallet address" });
+        return;
+      }
+      const normalizedAddress = walletAddress.toLowerCase();
+
+      const signerPrivateKey =
+        process.env.JUICER_SIGNER_PRIVATE_KEY ||
+        process.env.CAMPAIGN_SIGNER_PRIVATE_KEY;
+      if (!signerPrivateKey) {
+        log.error("JUICER_SIGNER_PRIVATE_KEY not configured");
+        res.status(500).json({ message: "NFT claiming not configured" });
+        return;
+      }
+
+      const contractAddress = getJuicerNftContract(JUICER_CAMPAIGN_CHAIN_ID);
+      if (!contractAddress) {
+        log.error("JUICER_NFT_CONTRACT_MAINNET not configured");
+        res.status(500).json({ message: "NFT claiming not configured" });
+        return;
+      }
+
+      // Gate 1: the 5,000 JP spend must be on the ledger.
+      const spend = await fetchJuicerSpend(normalizedAddress);
+      if (!spend) {
+        res.status(403).json({
+          message: `Trade ${JUICER_JP_COST} JP first`,
+          jpSpent: false,
+        });
+        return;
+      }
+
+      // Gate 2: social verifications.
+      const user = await prisma.user.findUnique({
+        where: { address: normalizedAddress },
+        include: { juicerCampaign: true },
+      });
+      const campaign = user?.juicerCampaign ?? null;
+      const twitterVerified = !!campaign?.twitterVerifiedAt;
+      const discordVerified = !!campaign?.discordVerifiedAt;
+      if (!twitterVerified || !discordVerified) {
+        res.status(403).json({
+          message: "Complete all verification steps first",
+          twitterVerified,
+          discordVerified,
+        });
+        return;
+      }
+
+      // Gate 3: meme token created on the campaign chain. Verified against
+      // Ponder; fail closed when the indexer is unreachable.
+      try {
+        const breakdown = await fetchEarnedPoints(log, normalizedAddress);
+        if (!breakdown.bonuses?.memeTokenCreated) {
+          res.status(403).json({
+            message: "Create a meme token on Citrea Mainnet first",
+            memeTokenCreated: false,
+          });
+          return;
+        }
+      } catch (error: any) {
+        log.error(
+          { error: error.message, context: "meme-token gate" },
+          "Failed to verify meme token — failing closed",
+        );
+        res
+          .status(503)
+          .json({ message: "Could not verify eligibility; please retry" });
+        return;
+      }
+
+      // Gate 4: not already claimed. Best-effort — the contract's hasClaimed
+      // mapping is the authoritative double-claim guard.
+      const alreadyClaimed = await fetchNftMinted(log, normalizedAddress);
+      if (alreadyClaimed === true) {
+        res
+          .status(403)
+          .json({ message: "NFT already claimed", alreadyClaimed: true });
+        return;
+      }
+
+      // Signature matches JuicerNFT.sol:
+      //   keccak256(abi.encodePacked(address(this), block.chainid, msg.sender))
+      const signature = await buildJuicerClaimSignature(
+        signerPrivateKey,
+        contractAddress,
+        JUICER_CAMPAIGN_CHAIN_ID,
+        normalizedAddress,
+      );
+
+      log.info(
+        {
+          walletAddress: normalizedAddress,
+          contractAddress,
+          signerAddress: new ethers.Wallet(signerPrivateKey).address,
+        },
+        "Juicer NFT claim signature generated",
+      );
+      res.status(200).json({ signature, contractAddress });
+    } catch (error: any) {
+      log.error(
+        { error: error.message, stack: error.stack },
+        "Error in handleJuicerNftSignature",
+      );
+      res.status(500).json({ message: "Failed to generate signature" });
+    }
+  };
+}

--- a/src/lib/constants/campaigns.ts
+++ b/src/lib/constants/campaigns.ts
@@ -13,6 +13,37 @@ export const FIRST_SQUEEZER_NFT_CONTRACT =
 export const FIRST_SQUEEZER_TESTNET_NFT_CONTRACT =
   "0x428B878cB6383216AaDc4e8495037E8d31612621" as const;
 
+// ---------------------------------------------------------------------------
+// Juicer NFT campaign
+// ---------------------------------------------------------------------------
+
+// JP that must be spent (burned off the available balance) to unlock the
+// Juicer NFT claim. Must match JUICER_JP_COST in the frontend campaign types.
+export const JUICER_JP_COST = 5_000 as const;
+
+// Reason tag written to the JpSpend ledger for the Juicer claim. Part of the
+// (walletAddress, chainId, reason) idempotency key.
+export const JUICER_SPEND_REASON = "juicer_nft" as const;
+
+// Canonical chain for the Juicer campaign (mirrors JUICER_CAMPAIGN_CHAIN_ID in
+// the Ponder points engine). The meme-token-created condition and the on-chain
+// claim are both scoped to this chain.
+export const JUICER_CAMPAIGN_CHAIN_ID = 4114 as const; // Citrea Mainnet
+
+// Deployed JuicerNFT.sol addresses. Sourced from env first so a fresh
+// deployment can be wired in without a code change; the empty-string fallback
+// makes a missing deployment fail loudly in /nft/signature rather than
+// silently signing against the zero address.
+export const JUICER_NFT_CONTRACT_MAINNET =
+  process.env.JUICER_NFT_CONTRACT_MAINNET || "";
+export const JUICER_NFT_CONTRACT_TESTNET =
+  process.env.JUICER_NFT_CONTRACT_TESTNET || "";
+
+export function getJuicerNftContract(chainId: number): string {
+  if (chainId === 5115) return JUICER_NFT_CONTRACT_TESTNET;
+  return JUICER_NFT_CONTRACT_MAINNET;
+}
+
 // JuiceSwap Discord server (guild) ID.
 export const DISCORD_GUILD_ID = "1416006072748998720" as const;
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -47,6 +47,14 @@ import {
   createNFTSignatureHandler,
   createFirstSqueezerEligibilityHandler,
 } from "./endpoints/firstSqueezerCampaign";
+import {
+  createJuicerProgressHandler,
+  createJuicerSpendHandler,
+  createJuicerTwitterMarkFollowedHandler,
+  createJuicerDiscordStartHandler,
+  createJuicerDiscordCallbackHandler,
+  createJuicerNftSignatureHandler,
+} from "./endpoints/juicerCampaign";
 import { quoteLimiter, generalLimiter } from "./middleware/rateLimiter";
 import {
   validateBody,
@@ -327,6 +335,14 @@ async function bootstrap() {
   const handleNFTSignature = createNFTSignatureHandler(logger);
   const handleFirstSqueezerEligibility =
     createFirstSqueezerEligibilityHandler(logger);
+  const handleJuicerProgress = createJuicerProgressHandler(logger);
+  const handleJuicerSpend = createJuicerSpendHandler(logger);
+  const handleJuicerTwitterMarkFollowed =
+    createJuicerTwitterMarkFollowedHandler(logger);
+  const handleJuicerDiscordStart = createJuicerDiscordStartHandler(logger);
+  const handleJuicerDiscordCallback =
+    createJuicerDiscordCallbackHandler(logger);
+  const handleJuicerNftSignature = createJuicerNftSignatureHandler(logger);
   const handleLightningInvoice = createLightningInvoiceHandler(logger);
   const handleValidateLightningAddress =
     createValidateLightningAddressHandler(logger);
@@ -644,6 +660,34 @@ async function bootstrap() {
     "/v1/campaigns/first-squeezer/eligibility",
     generalLimiter,
     handleFirstSqueezerEligibility,
+  );
+
+  // Juicer NFT campaign endpoints
+  app.get(
+    "/v1/campaigns/juicer/progress",
+    generalLimiter,
+    handleJuicerProgress,
+  );
+  app.post("/v1/campaigns/juicer/spend", generalLimiter, handleJuicerSpend);
+  app.post(
+    "/v1/campaigns/juicer/twitter/mark-followed",
+    generalLimiter,
+    handleJuicerTwitterMarkFollowed,
+  );
+  app.get(
+    "/v1/campaigns/juicer/discord/start",
+    generalLimiter,
+    handleJuicerDiscordStart,
+  );
+  app.get(
+    "/v1/campaigns/juicer/discord/callback",
+    generalLimiter,
+    handleJuicerDiscordCallback,
+  );
+  app.get(
+    "/v1/campaigns/juicer/nft/signature",
+    generalLimiter,
+    handleJuicerNftSignature,
   );
 
   // Bridge Swap endpoints

--- a/src/services/DiscordOAuthService.ts
+++ b/src/services/DiscordOAuthService.ts
@@ -91,6 +91,7 @@ export class DiscordOAuthService {
    */
   public async generateAuthUrl(
     walletAddress: string,
+    callbackUrlOverride?: string,
   ): Promise<{ authUrl: string; state: string }> {
     // Generate state for CSRF protection
     const state = generateState();
@@ -98,11 +99,14 @@ export class DiscordOAuthService {
     // Calculate expiry time (10 minutes from now)
     const expiresAt = new Date(Date.now() + this.SESSION_EXPIRY_MS);
 
-    // Store session in database
+    // Store session in database. The callback override (if any) is persisted
+    // with the session because Discord requires the token exchange to repeat
+    // the exact redirect_uri used in the authorize step.
     await prisma.discordOAuthSession.create({
       data: {
         state,
         walletAddress,
+        callbackUrl: callbackUrlOverride ?? null,
         expiresAt,
       },
     });
@@ -111,7 +115,7 @@ export class DiscordOAuthService {
     const params = new URLSearchParams({
       response_type: "code",
       client_id: this.config.clientId,
-      redirect_uri: this.config.callbackUrl,
+      redirect_uri: callbackUrlOverride ?? this.config.callbackUrl,
       scope: this.SCOPES,
       state,
     });
@@ -155,7 +159,8 @@ export class DiscordOAuthService {
           client_secret: this.config.clientSecret,
           grant_type: "authorization_code",
           code,
-          redirect_uri: this.config.callbackUrl,
+          // Must match the redirect_uri used at authorize time (override or default).
+          redirect_uri: session.callbackUrl ?? this.config.callbackUrl,
         }),
         {
           headers: {


### PR DESCRIPTION
## What
The missing backend for the Juicer NFT campaign. The frontend page (bapp#741) and JuicerNFT.sol (smart-contracts#56) were both built against /v1/campaigns/juicer/* endpoints that did not exist. This adds them, mirroring the First Squeezer patterns.

## Endpoints
- GET /progress — Ponder-earned JP + JpSpend ledger + social state + on-chain hasClaimed (availableJp = earned - spent)
- POST /spend — atomic, idempotent 5,000 JP trade ((walletAddress,chainId,reason) unique; P2002-deduped); fails closed if Ponder is down
- POST /twitter/mark-followed — honor-system X follow (First Squeezer parity)
- GET /discord/start|callback — Discord OAuth requiring the Juicer role; one Discord per wallet
- GET /nft/signature — EIP-191 signature for JuicerNFT.claim(); gates on spend + socials + meme-token (verified vs Ponder, fail-closed) + not-already-claimed

## Schema
New Prisma models JuicerCampaignUser and JpSpend (authoritative off-chain spend side). DiscordOAuthSession gains a callbackUrl column so a per-flow OAuth redirect survives the token exchange.

## Wiring (required before claims work)
- JUICER_NFT_CONTRACT_MAINNET/_TESTNET and JUICER_SIGNER_PRIVATE_KEY (address MUST equal the deployed contract signer).
- Register JUICER_DISCORD_CALLBACK_URL as a Discord redirect URI.

## Tests
46/46 jest green incl. signature contract-compatibility. tsc clean. Prisma migration included.

Depends on JuiceSwapxyz/ponder#139 for the earn-side data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)