### PR TITLE
fix(first-squeezer): default eligibility gate to public testnet RPC

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,9 +23,10 @@ PONDER_FALLBACK_URL=https://dev.ponder.juiceswap.com
 # Citrea RPC URL
 CITREA_4114_RPC_URL=https://rpc.citreascan.com/
 
-# Citrea Testnet RPC — used ONLY by the First Squeezer campaign eligibility gate
-# to read the historical testnet NFT claim. Points at the public testnet RPC.
-CITREA_5115_RPC_URL=https://rpc.testnet.citrea.xyz
+# Citrea Testnet RPC — OPTIONAL override, used ONLY by the First Squeezer
+# campaign eligibility gate to read the historical testnet NFT claim. If unset,
+# the code defaults to the public testnet RPC (https://rpc.testnet.citrea.xyz).
+# CITREA_5115_RPC_URL=https://rpc.testnet.citrea.xyz
 
 # Rate Limiting
 RATE_LIMIT_QUOTE_PER_MINUTE=2000

--- a/src/endpoints/firstSqueezerCampaign.ts
+++ b/src/endpoints/firstSqueezerCampaign.ts
@@ -16,18 +16,20 @@ import {
  * First Squeezer Campaign - Social OAuth Endpoints (Twitter & Discord)
  */
 
+// Public Citrea Testnet RPC. The testnet chain still lives on public infra
+// after DFX's own node is decommissioned, and the historical First Squeezer
+// claim data is immutable, so the gate reads it here by default.
+const CITREA_TESTNET_PUBLIC_RPC_URL = "https://rpc.testnet.citrea.xyz";
+
 /**
  * Returns true if the wallet ran claim() on the testnet First Squeezer NFT
  * contract (Oct 2025 campaign). Used by the mainnet claim eligibility gate.
  * Throws on RPC failure — callers must fail closed, not permit claims.
  */
 async function hasClaimedTestnetNFT(walletAddress: string): Promise<boolean> {
-  if (!process.env.CITREA_5115_RPC_URL) {
-    throw new Error("CITREA_5115_RPC_URL not configured");
-  }
-  const provider = new ethers.providers.JsonRpcProvider(
-    process.env.CITREA_5115_RPC_URL,
-  );
+  const rpcUrl =
+    process.env.CITREA_5115_RPC_URL || CITREA_TESTNET_PUBLIC_RPC_URL;
+  const provider = new ethers.providers.JsonRpcProvider(rpcUrl);
   const contract = new ethers.Contract(
     FIRST_SQUEEZER_TESTNET_NFT_CONTRACT,
     ["function hasClaimed(address) view returns (bool)"],


### PR DESCRIPTION
## What

The First Squeezer **mainnet** claim gate checks the wallet's **historical testnet** NFT claim via `hasClaimedTestnetNFT`, reading `CITREA_5115_RPC_URL`. In prod that env points at DFX's local `citread` node (`host.docker.internal:8085`), which is being decommissioned in the Citrea Testnet sunset — so the gate would break (fail closed → nobody eligible).

This defaults the gate's RPC to the **public** testnet RPC in code; the env var stays as an optional override:

```ts
const rpcUrl = process.env.CITREA_5115_RPC_URL || "https://rpc.testnet.citrea.xyz"
```

## Why the public testnet RPC (and not mainnet)

- The testnet chain lives on public infra (`rpc.testnet.citrea.xyz`, chainId `0x13fb`/5115) after DFX's node dies, and the Oct 2025 claim data is immutable → durable + correct.
- **Verified on-chain:** the contract `0x428B…` has code there and `hasClaimed(...)` responds.
- ⚠️ The same address on **mainnet** is a *different contract* (different bytecode — the deployment-nonce coincidence noted in `campaigns.ts`), so `CITREA_4114_RPC_URL` can't be used — it wouldn't reflect testnet claims.

Fail-closed behavior is preserved (RPC/contract errors still throw → callers reject the claim).

## Follow-up (separate, later)

Once this is on prod, the server-repo `CITREA_5115_RPC_URL` lines for `jsw-api`/`jsw-ponder` become removable as a safe no-op (jsw-ponder's is already dead; jsw-api's is now covered by this code default).

## Checks (local)

- `tsc --noEmit` ✅
- `prettier --check` ✅
- `jest` ✅ (103 passed, 3 skipped)