### PR TITLE
chore(routing): disable JuiceDollar routing for quote and swap

### DIFF
--- a/src/endpoints/__tests__/quoteSwapGatewayDisabled.test.ts
+++ b/src/endpoints/__tests__/quoteSwapGatewayDisabled.test.ts
@@ -1,0 +1,106 @@
+import { ChainId } from "@juiceswapxyz/sdk-core";
+import Logger from "bunyan";
+import { getChainContracts } from "../../config/contracts";
+import { createQuoteHandler } from "../quote";
+import { createSwapHandler } from "../swap";
+
+jest.mock("../../services/LaunchpadTokenService", () => ({
+  isGraduatedLaunchpadToken: jest.fn().mockResolvedValue(false),
+}));
+jest.mock("../../services/userTracking", () => ({
+  trackUser: jest.fn(),
+}));
+
+function createMockLogger(): Logger {
+  const logger = {
+    child: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+  return logger as unknown as Logger;
+}
+
+function createMockResponse() {
+  return {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+    setHeader: jest.fn().mockReturnThis(),
+  };
+}
+
+// Production wiring (src/server.ts) passes `undefined` for juiceGatewayService
+// into createQuoteHandler/createSwapHandler so quote/swap always resolve via
+// Classic Uniswap routing. These tests pin that exact shape, since the rest of
+// the suite only ever exercises these handlers with a live JuiceGatewayService.
+describe("Quote/swap with JuiceDollar Gateway routing disabled", () => {
+  const chainId = ChainId.CITREA_MAINNET;
+  const contracts = getChainContracts(chainId)!;
+  let logger: Logger;
+
+  it("quote: JUSD -> JUICE falls through to the Classic router instead of Gateway's direct conversion", async () => {
+    logger = createMockLogger();
+    // With Gateway live, JUSD -> JUICE resolves as an isDirectConversion route
+    // (Equity.invest()) and never calls routerService.getQuote at all — so
+    // getQuote being called here is unambiguous proof Gateway did not run.
+    const body = {
+      tokenIn: contracts.JUSD,
+      tokenOut: contracts.JUICE,
+      tokenInChainId: chainId,
+      tokenOutChainId: chainId,
+      tokenInDecimals: 18,
+      tokenOutDecimals: 18,
+      amount: "1000000000000000000",
+      type: "EXACT_INPUT",
+      swapper: "0x000000000000000000000000000000000000dead",
+    };
+    const routerService = {
+      isChainSupported: jest.fn().mockReturnValue(true),
+      getQuote: jest.fn().mockRejectedValue(new Error("CLASSIC_PATH_REACHED")),
+    };
+    const handler = createQuoteHandler(routerService as any, logger, undefined);
+    const res = createMockResponse();
+
+    await handler({ body, headers: {} } as any, res as any);
+
+    expect(routerService.getQuote).toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalledWith(
+      expect.objectContaining({ error: "NO_ROUTE" }),
+    );
+  });
+
+  it("swap: JUSD -> JUICE falls through to the Classic router instead of Gateway's direct conversion", async () => {
+    logger = createMockLogger();
+    const body = {
+      tokenIn: contracts.JUSD,
+      tokenOut: contracts.JUICE,
+      tokenInChainId: chainId,
+      tokenOutChainId: chainId,
+      amount: "1000000000000000000",
+      type: "exactIn",
+      recipient: "0x000000000000000000000000000000000000dead",
+      from: "0x000000000000000000000000000000000000dead",
+      slippageTolerance: "0.5",
+    };
+    const routerService = {
+      isChainSupported: jest.fn().mockReturnValue(true),
+      getTokenInfo: jest
+        .fn()
+        .mockRejectedValue(new Error("CLASSIC_PATH_REACHED")),
+    };
+    const handler = createSwapHandler(routerService as any, logger, undefined);
+    const res = createMockResponse();
+
+    await handler({ body, headers: {} } as any, res as any);
+
+    // getTokenInfo is only ever called from the Classic swap path (Gateway
+    // swaps resolve token info via the Gateway service instead), so this
+    // proves the request never entered Gateway routing.
+    expect(routerService.getTokenInfo).toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalledWith(
+      expect.objectContaining({ error: "NO_ROUTE" }),
+    );
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -263,16 +263,18 @@ async function bootstrap() {
   });
 
   // Create endpoint handlers
+  // JuiceDollar routing disabled for quote/swap: omitting juiceGatewayService
+  // makes both handlers fall back to normal Uniswap routing for every request.
   const handleQuote = createQuoteHandler(
     routerService,
     logger,
-    juiceGatewayService,
+    undefined,
     satsumaPoolService,
   );
   const handleSwap = createSwapHandler(
     routerService,
     logger,
-    juiceGatewayService,
+    undefined,
     satsumaPoolService,
   );
   const handleSwappableTokens = createSwappableTokensHandler(logger);
@@ -349,7 +351,7 @@ async function bootstrap() {
     routerService,
     logger,
     exploreStatsService,
-    juiceGatewayService,
+    undefined,
   );
   const handlePoolDetails = createPoolDetailsHandler(
     providers,

--- a/src/server.ts
+++ b/src/server.ts
@@ -347,12 +347,7 @@ async function bootstrap() {
     logger,
     svJusdPriceService,
   );
-  initializeResolvers(
-    routerService,
-    logger,
-    exploreStatsService,
-    undefined,
-  );
+  initializeResolvers(routerService, logger, exploreStatsService, undefined);
   const handlePoolDetails = createPoolDetailsHandler(
     providers,
     logger,


### PR DESCRIPTION
## Summary
- Quote and swap requests — REST `/v1/quote`, `/v1/swap`, and the GraphQL `quote` query (GraphQL exposes no swap mutation) — no longer route through the JuiceDollar Gateway; they resolve through normal Uniswap Classic routing.
- Done by no longer passing `juiceGatewayService` into `createQuoteHandler`/`createSwapHandler` and into `initializeResolvers` in `src/server.ts`. Both handler factories already treat the service as optional, so omitting it makes the `juiceGatewayService && hasJuiceDollarIntegration(chainId)` gate short-circuit false in `quote.ts`/`swap.ts`.
- LP endpoints (`lpCreate`/`lpIncrease`/`lpDecrease`/`lpApprove`/`lpClaim`) and the `GATEWAY_DEPOSIT_DISABLED` savings-rate guard are untouched — this only affects quote/swap routing.

## Known behavior change
Any pair involving a JuiceDollar-side USD token (JUSD, svJUSD, SUSD, USDC.e, USDT, CTUSD) previously got a Gateway bridge conversion (near 1:1, not dependent on pool depth) whenever quoted or swapped. With Gateway disabled here, those pairs now price/execute against whatever Classic Uniswap pool exists for them instead — which for some pairs is thin (e.g. the JuiceSwap V3 USDC.e/ctUSD pool holds ~$5k/side) or may not exist at all (`NO_ROUTE`). `EXACT_INPUT` on USDC.e/ctUSD is still protected by the existing Satsuma cross-DEX comparison; `EXACT_OUTPUT` on that pair, and any other USD-token pair without a comparable fallback, is not. Flagging this for awareness before merge — it's the direct, intended consequence of disabling Gateway routing for quote/swap, not something this PR works around.

## Test plan
- [x] `tsc --noEmit` — clean
- [x] `eslint src --ext .ts` — 0 errors (pre-existing warnings only)
- [x] `jest` — 109 passed, 3 skipped (pre-existing, unrelated integration test); added `src/endpoints/__tests__/quoteSwapGatewayDisabled.test.ts` covering the exact `undefined`-service wiring shape used in production