### PR TITLE
9cfe3211 - chore(bridge-swap): disable swap creation and status syncing

### DIFF
--- a/src/config/swap-bridge.ts
+++ b/src/config/swap-bridge.ts
@@ -1,5 +1,10 @@
 import { ChainId } from "@juiceswapxyz/sdk-core";
 
+// The Boltz-based swap backend and claim indexer this feature depends on
+// have been decommissioned. New swaps and status syncing are disabled until
+// a replacement backend is wired up; existing swap records remain readable.
+export const BRIDGE_SWAP_ENABLED = false;
+
 export enum BridgeAsset {
   BTC = "BTC",
   cBTC = "cBTC",

--- a/src/endpoints/bridgeSwap/claimRefund.ts
+++ b/src/endpoints/bridgeSwap/claimRefund.ts
@@ -5,6 +5,7 @@ import Logger from "bunyan";
 import { computeClaimableAndRefundableEvmSwaps } from "../../services/EvmBridgeClaimRefund";
 import { computeRefundableBtcChainSwaps } from "../../services/BtcChainSwapRefund";
 import { syncBridgeSwapStatuses } from "../../services/BridgeSwapStatusSyncer";
+import { BRIDGE_SWAP_ENABLED } from "../../config/swap-bridge";
 
 export function createClaimRefundHandler(
   providerMap: Map<ChainId, providers.StaticJsonRpcProvider>,
@@ -25,7 +26,9 @@ export function createClaimRefundHandler(
     delete req.headers["if-modified-since"];
 
     try {
-      await syncBridgeSwapStatuses(userId, logger);
+      if (BRIDGE_SWAP_ENABLED) {
+        await syncBridgeSwapStatuses(userId, logger);
+      }
 
       const evm = await computeClaimableAndRefundableEvmSwaps(
         userId,

--- a/src/endpoints/bridgeSwap/createBridgeSwap.ts
+++ b/src/endpoints/bridgeSwap/createBridgeSwap.ts
@@ -5,12 +5,21 @@ import {
   serializeBridgeSwap,
   toSwapData,
 } from "../../utils/bridgeSwapSerialize";
+import { BRIDGE_SWAP_ENABLED } from "../../config/swap-bridge";
 
 export function createBridgeSwapHandler(logger: Logger) {
   return async function handleCreateBridgeSwap(
     req: Request,
     res: Response,
   ): Promise<void> {
+    if (!BRIDGE_SWAP_ENABLED) {
+      res.status(503).json({
+        error: "Service unavailable",
+        detail: "Bridge swaps are temporarily disabled.",
+      });
+      return;
+    }
+
     const startTime = Date.now();
 
     try {

--- a/src/endpoints/bridgeSwap/createBulkBridgeSwap.ts
+++ b/src/endpoints/bridgeSwap/createBulkBridgeSwap.ts
@@ -2,12 +2,21 @@ import { Request, Response } from "express";
 import Logger from "bunyan";
 import { prisma } from "../../db/prisma";
 import { toSwapData } from "../../utils/bridgeSwapSerialize";
+import { BRIDGE_SWAP_ENABLED } from "../../config/swap-bridge";
 
 export function createBulkBridgeSwapHandler(logger: Logger) {
   return async function handleBulkCreateBridgeSwap(
     req: Request,
     res: Response,
   ): Promise<void> {
+    if (!BRIDGE_SWAP_ENABLED) {
+      res.status(503).json({
+        error: "Service unavailable",
+        detail: "Bridge swaps are temporarily disabled.",
+      });
+      return;
+    }
+
     const startTime = Date.now();
 
     try {

--- a/src/endpoints/bridgeSwap/getBridgeSwapById.ts
+++ b/src/endpoints/bridgeSwap/getBridgeSwapById.ts
@@ -5,6 +5,7 @@ import { serializeBridgeSwap } from "../../utils/bridgeSwapSerialize";
 import { BtcOnchainIndexerService } from "../../services/BtcOnchainIndexerService";
 import { buildFixSwapStatuses } from "../../utils/statusFixers";
 import { EvmBridgeIndexer } from "../../services/EvmBrigdeIndexer";
+import { BRIDGE_SWAP_ENABLED } from "../../config/swap-bridge";
 
 export function createGetBridgeSwapByIdHandler(logger: Logger) {
   return async function handleGetBridgeSwapById(
@@ -31,15 +32,19 @@ export function createGetBridgeSwapByIdHandler(logger: Logger) {
         return;
       }
 
-      const btcOnchainIndexerService = new BtcOnchainIndexerService(logger);
-      const evmBridgeIndexerService = new EvmBridgeIndexer(logger);
+      let resolvedSwap = bridgeSwap;
 
-      const fixSwapStatuses = buildFixSwapStatuses({
-        btcOnchainIndexerService,
-        evmBridgeIndexerService,
-      });
+      if (BRIDGE_SWAP_ENABLED) {
+        const btcOnchainIndexerService = new BtcOnchainIndexerService(logger);
+        const evmBridgeIndexerService = new EvmBridgeIndexer(logger);
 
-      const [resolvedSwap] = await fixSwapStatuses([bridgeSwap]);
+        const fixSwapStatuses = buildFixSwapStatuses({
+          btcOnchainIndexerService,
+          evmBridgeIndexerService,
+        });
+
+        [resolvedSwap] = await fixSwapStatuses([bridgeSwap]);
+      }
 
       if (resolvedSwap !== bridgeSwap) {
         await prisma.bridgeSwap.update({

--- a/src/endpoints/bridgeSwap/getBridgeSwapByPreimageHash.ts
+++ b/src/endpoints/bridgeSwap/getBridgeSwapByPreimageHash.ts
@@ -6,6 +6,7 @@ import { BtcOnchainIndexerService } from "../../services/BtcOnchainIndexerServic
 import { buildFixSwapStatuses } from "../../utils/statusFixers";
 import { EvmBridgeIndexer } from "../../services/EvmBrigdeIndexer";
 import { unprefix0x } from "../../utils/hex";
+import { BRIDGE_SWAP_ENABLED } from "../../config/swap-bridge";
 
 export function createGetBridgeSwapByPreimageHashHandler(logger: Logger) {
   return async function handleGetBridgeSwapByPreimageHash(
@@ -28,15 +29,19 @@ export function createGetBridgeSwapByPreimageHashHandler(logger: Logger) {
         return;
       }
 
-      const btcOnchainIndexerService = new BtcOnchainIndexerService(logger);
-      const evmBridgeIndexerService = new EvmBridgeIndexer(logger);
+      let resolvedSwap = bridgeSwap;
 
-      const fixSwapStatuses = buildFixSwapStatuses({
-        btcOnchainIndexerService,
-        evmBridgeIndexerService,
-      });
+      if (BRIDGE_SWAP_ENABLED) {
+        const btcOnchainIndexerService = new BtcOnchainIndexerService(logger);
+        const evmBridgeIndexerService = new EvmBridgeIndexer(logger);
 
-      const [resolvedSwap] = await fixSwapStatuses([bridgeSwap]);
+        const fixSwapStatuses = buildFixSwapStatuses({
+          btcOnchainIndexerService,
+          evmBridgeIndexerService,
+        });
+
+        [resolvedSwap] = await fixSwapStatuses([bridgeSwap]);
+      }
 
       if (resolvedSwap !== bridgeSwap) {
         await prisma.bridgeSwap.update({

--- a/src/endpoints/bridgeSwap/getBridgeSwapsByUser.ts
+++ b/src/endpoints/bridgeSwap/getBridgeSwapsByUser.ts
@@ -8,6 +8,7 @@ import {
   swapStatusPending,
   swapStatusSuccess,
 } from "../../types/BridgeSwapsStatus";
+import { BRIDGE_SWAP_ENABLED } from "../../config/swap-bridge";
 
 export function createGetBridgeSwapsByUserHandler(logger: Logger) {
   return async function handleGetBridgeSwapsByUser(
@@ -20,7 +21,9 @@ export function createGetBridgeSwapsByUserHandler(logger: Logger) {
     const status = req.query.status as string | string[] | undefined;
 
     try {
-      await syncBridgeSwapStatuses(userId, logger);
+      if (BRIDGE_SWAP_ENABLED) {
+        await syncBridgeSwapStatuses(userId, logger);
+      }
 
       const statusFilter = Array.isArray(status)
         ? { in: status }

--- a/src/endpoints/bridgeSwap/myBridgeSwapsSummary.ts
+++ b/src/endpoints/bridgeSwap/myBridgeSwapsSummary.ts
@@ -7,6 +7,7 @@ import {
   swapStatusSuccess,
 } from "../../types/BridgeSwapsStatus";
 import { syncBridgeSwapStatuses } from "../../services/BridgeSwapStatusSyncer";
+import { BRIDGE_SWAP_ENABLED } from "../../config/swap-bridge";
 
 export function createMyBridgeSwapsSummaryHandler(logger: Logger) {
   return async function handleMyBridgeSwapsSummary(
@@ -16,7 +17,9 @@ export function createMyBridgeSwapsSummaryHandler(logger: Logger) {
     const userId = req.user!.address;
 
     try {
-      await syncBridgeSwapStatuses(userId, logger);
+      if (BRIDGE_SWAP_ENABLED) {
+        await syncBridgeSwapStatuses(userId, logger);
+      }
 
       const [
         totalPendingSwaps,


### PR DESCRIPTION
EN:
The Boltz-based swap backend and claim indexer this feature depends on have been decommissioned, so every write and status-sync call in the bridge-swap flow has been failing. This guards new-swap creation and status syncing behind a disabled flag while keeping existing swap records readable at their last known status.

DE:
Das Boltz-basierte Swap-Backend und der Claim-Indexer, von denen dieses Feature abhängt, wurden stillgelegt, daher scheitern alle Schreib- und Status-Sync-Aufrufe im Bridge-Swap-Flow. Dieser PR sperrt das Erstellen neuer Swaps und das Status-Syncing hinter einem deaktivierten Flag, bestehende Swap-Datensätze bleiben mit ihrem letzten bekannten Status lesbar.

<details>
<summary>Details</summary>

- `EvmBridgeIndexer` (`https://lightning.space/v1/claim`) and `LdsBridgeService` (`https://lightning.space/v1/swap/v2/swap/*`) both 404 on every call — the backend they talk to no longer exists.
- Added `BRIDGE_SWAP_ENABLED = false` in `src/config/swap-bridge.ts`.
- `POST /v1/bridge-swap` and `POST /v1/bridge-swap/bulk` now return 503 immediately instead of writing a swap record that can never progress.
- `GET /v1/bridge-swap/user`, `GET /v1/my-bridge-swaps-summary`, and `GET /v1/bridge-swap/claim-refund` skip the doomed `syncBridgeSwapStatuses` call and serve last-known DB state.
- `GET /v1/bridge-swap/:id` and `GET /v1/bridge-swap/preimage-hash/:preimageHash` skip `fixSwapStatuses` — this also fixes a live bug: both endpoints currently throw and return 500 on every request, since that call isn't wrapped the way the others are.
- Left `computeClaimableAndRefundableEvmSwaps`/`computeRefundableBtcChainSwaps` inside `claim-refund` untouched: this is the recovery path for funds already locked in a swap, and I didn't want to change its error behavior without a closer look at whether users currently rely on it. The EVM leg will still throw against the dead indexer (existing behavior, unchanged); worth a follow-up.
- No test changes needed — `npm run typecheck`, `npm run lint`, and `npm test` all pass; no existing tests cover this flow.

</details>