### PR TITLE
502f613c - chore(stats): drop JuiceDollar bridge-volume leg from ProtocolStatsService

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,8 +67,7 @@ DISCORD_CALLBACK_URL=http://localhost:3000/v1/campaigns/first-squeezer/discord/c
 # IMPORTANT: This address must match CAMPAIGN_SIGNER_ADDRESS in smart-contracts/.env
 CAMPAIGN_SIGNER_PRIVATE_KEY=your_campaign_signer_private_key_here
 
-# Bridge Ponder APIs (for protocol stats)
-JUICEDOLLAR_PONDER_URL=https://ponder.juicedollar.com
+# Bridge Ponder API (for protocol stats)
 LDS_PONDER_URL=https://lightning.space/v1/claim
 
 # Pinata IPFS Configuration (Launchpad Token Metadata)

--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ Returns TVL and 24h volume for the Explore page. All values are in USD.
 
 Sum of V2 + V3 + Bridge 24h volume.
 
-| Component  | Source                                                                | Method                                                             |
-| ---------- | --------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| **V3**     | `ExploreStatsService` (pre-computed `volume1Day` per pool)            | Sum of per-pool 24h USD volumes                                    |
-| **V2**     | `ExploreStatsService` (pre-computed `volume1Day` per pool)            | Sum of per-pool 24h USD volumes                                    |
-| **Bridge** | JuiceDollar Ponder (`bridgeVolumeStats`) + LDS Ponder (`volumeStats`) | Stablecoin bridges: JUSD at $1. LDS: cBTC × BTC price + JUSD at $1 |
+| Component  | Source                                                     | Method                             |
+| ---------- | ---------------------------------------------------------- | ---------------------------------- |
+| **V3**     | `ExploreStatsService` (pre-computed `volume1Day` per pool) | Sum of per-pool 24h USD volumes    |
+| **V2**     | `ExploreStatsService` (pre-computed `volume1Day` per pool) | Sum of per-pool 24h USD volumes    |
+| **Bridge** | LDS Ponder (`volumeStats`)                                 | LDS: cBTC × BTC price + JUSD at $1 |
 
 ### TVL
 

--- a/src/services/ProtocolStatsService.ts
+++ b/src/services/ProtocolStatsService.ts
@@ -44,7 +44,7 @@ interface StatsCache {
  * ProtocolStatsService - Aggregates TVL and volume across V2, V3, and bridge
  *
  * V2/V3 stats: Derived by summing per-pool data from ExploreStatsService
- * Bridge stats: Fetched directly via RPC multicall and external Ponder instances
+ * Bridge stats: Fetched directly via RPC multicall and the LDS Ponder instance
  */
 export class ProtocolStatsService {
   private logger: Logger;
@@ -162,13 +162,13 @@ export class ProtocolStatsService {
 
   /**
    * Bridge stats: TVL from StablecoinBridge minted() totals,
-   * volume from JuiceDollar Ponder + LDS Ponder GraphQL queries
+   * volume from the LDS Ponder GraphQL query
    */
   private async getBridgeStats(chainId: number): Promise<ProtocolStats> {
     try {
       const [tvlUsd, volume24hUsd] = await Promise.all([
         this.getBridgeTvl(chainId),
-        this.getBridgeVolume(chainId),
+        this.getLdsBridgeVolume(chainId),
       ]);
 
       this.logger.info(
@@ -227,57 +227,6 @@ export class ProtocolStatsService {
       return totalMinted;
     } catch (error) {
       this.logger.warn({ error }, "Failed to fetch bridge TVL via multicall");
-      return 0;
-    }
-  }
-
-  /**
-   * Bridge volume = stablecoin bridge volume + LDS bridge volume (24h).
-   */
-  private async getBridgeVolume(chainId: number): Promise<number> {
-    const [stablecoinVolume, ldsVolume] = await Promise.all([
-      this.getStablecoinBridgeVolume(),
-      this.getLdsBridgeVolume(chainId),
-    ]);
-    return stablecoinVolume + ldsVolume;
-  }
-
-  /**
-   * Query JuiceDollar Ponder for rolling 24h stablecoin bridge volume.
-   * Uses hourly buckets with a 24h-ago cutoff. All values are JUSD (18 decimals, $1).
-   */
-  private async getStablecoinBridgeVolume(): Promise<number> {
-    try {
-      const baseUrl =
-        process.env.JUICEDOLLAR_PONDER_URL || "https://ponder.juicedollar.com";
-      const cutoff = this.get24hAgoCutoff();
-      const query = `
-        query {
-          bridgeVolumeStats(where: { type: "1h", timestamp_gte: "${cutoff}" }, orderBy: "timestamp", orderDirection: "desc", limit: 200) {
-            items { stablecoinAddress, timestamp, volume, type }
-          }
-        }
-      `;
-
-      const response = await axios.post(
-        `${baseUrl}/graphql`,
-        { query },
-        { timeout: 10000 },
-      );
-
-      const items = response.data?.data?.bridgeVolumeStats?.items || [];
-      let totalVolume = 0;
-      for (const item of items) {
-        totalVolume += parseFloat(
-          ethers.utils.formatUnits(item.volume || "0", 18),
-        );
-      }
-      return totalVolume;
-    } catch (error) {
-      this.logger.warn(
-        { error },
-        "Failed to fetch stablecoin bridge volume from JuiceDollar Ponder",
-      );
       return 0;
     }
   }

--- a/src/services/__tests__/ProtocolStatsService.test.ts
+++ b/src/services/__tests__/ProtocolStatsService.test.ts
@@ -82,6 +82,9 @@ describe("ProtocolStatsService bridge volume", () => {
             },
           };
         }
+        if (!query.includes("volumeStats")) {
+          throw new Error(`Unexpected Ponder query: ${query}`);
+        }
         return {
           data: {
             data: {
@@ -110,6 +113,9 @@ describe("ProtocolStatsService bridge volume", () => {
     expect(mockedAxios.post).toHaveBeenCalledTimes(1);
     const [url, body] = mockedAxios.post.mock.calls[0];
     expect(url).toBe(`${LDS_PONDER_URL}/graphql`);
+    expect((body as { query: string }).query).toContain(
+      `volumeStats(where: { chainId: ${ChainId.CITREA_MAINNET}`,
+    );
     expect(JSON.stringify({ url, body })).not.toMatch(
       /juicedollar|bridgeVolumeStats/i,
     );

--- a/src/services/__tests__/ProtocolStatsService.test.ts
+++ b/src/services/__tests__/ProtocolStatsService.test.ts
@@ -42,9 +42,22 @@ function createService() {
   );
 }
 
+const LDS_PONDER_URL = "https://lds-ponder.test/v1/claim";
+
 describe("ProtocolStatsService bridge volume", () => {
+  const originalLdsPonderUrl = process.env.LDS_PONDER_URL;
+
+  afterAll(() => {
+    if (originalLdsPonderUrl === undefined) {
+      delete process.env.LDS_PONDER_URL;
+    } else {
+      process.env.LDS_PONDER_URL = originalLdsPonderUrl;
+    }
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
+    process.env.LDS_PONDER_URL = LDS_PONDER_URL;
     mockedAxios.post.mockResolvedValue({
       data: {
         data: {
@@ -70,7 +83,7 @@ describe("ProtocolStatsService bridge volume", () => {
 
     expect(mockedAxios.post).toHaveBeenCalledTimes(1);
     const [url, body] = mockedAxios.post.mock.calls[0];
-    expect(url).toContain("lightning.space");
+    expect(url).toBe(`${LDS_PONDER_URL}/graphql`);
     expect(JSON.stringify({ url, body })).not.toMatch(
       /juicedollar|bridgeVolumeStats/i,
     );

--- a/src/services/__tests__/ProtocolStatsService.test.ts
+++ b/src/services/__tests__/ProtocolStatsService.test.ts
@@ -58,22 +58,48 @@ describe("ProtocolStatsService bridge volume", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     process.env.LDS_PONDER_URL = LDS_PONDER_URL;
-    mockedAxios.post.mockResolvedValue({
-      data: {
-        data: {
-          volumeStats: {
-            items: [
-              {
-                tokenAddress: "0x0000000000000000000000000000000000000001",
-                timestamp: "1700000000",
-                volume: ethers.utils.parseUnits("7", 18).toString(),
-                type: "1h",
+    // Answers a JuiceDollar `bridgeVolumeStats` query with a non-zero volume, so
+    // a resurrected JuiceDollar leg would show up as 5 + 7 instead of 7.
+    mockedAxios.post.mockImplementation(
+      async (_url: string, body?: unknown) => {
+        const query = (body as { query?: string })?.query ?? "";
+        if (query.includes("bridgeVolumeStats")) {
+          return {
+            data: {
+              data: {
+                bridgeVolumeStats: {
+                  items: [
+                    {
+                      stablecoinAddress:
+                        "0x0000000000000000000000000000000000000002",
+                      timestamp: "1700000000",
+                      volume: ethers.utils.parseUnits("5", 18).toString(),
+                      type: "1h",
+                    },
+                  ],
+                },
               },
-            ],
+            },
+          };
+        }
+        return {
+          data: {
+            data: {
+              volumeStats: {
+                items: [
+                  {
+                    tokenAddress: "0x0000000000000000000000000000000000000001",
+                    timestamp: "1700000000",
+                    volume: ethers.utils.parseUnits("7", 18).toString(),
+                    type: "1h",
+                  },
+                ],
+              },
+            },
           },
-        },
+        };
       },
-    });
+    );
   });
 
   it("queries only the LDS Ponder, never the JuiceDollar Ponder", async () => {

--- a/src/services/__tests__/ProtocolStatsService.test.ts
+++ b/src/services/__tests__/ProtocolStatsService.test.ts
@@ -113,8 +113,10 @@ describe("ProtocolStatsService bridge volume", () => {
     expect(mockedAxios.post).toHaveBeenCalledTimes(1);
     const [url, body] = mockedAxios.post.mock.calls[0];
     expect(url).toBe(`${LDS_PONDER_URL}/graphql`);
-    expect((body as { query: string }).query).toContain(
-      `volumeStats(where: { chainId: ${ChainId.CITREA_MAINNET}`,
+    const { query } = body as { query: string };
+    expect(query).toContain("volumeStats");
+    expect(query).toMatch(
+      new RegExp(`chainId:\\s*${ChainId.CITREA_MAINNET}\\b`),
     );
     expect(JSON.stringify({ url, body })).not.toMatch(
       /juicedollar|bridgeVolumeStats/i,

--- a/src/services/__tests__/ProtocolStatsService.test.ts
+++ b/src/services/__tests__/ProtocolStatsService.test.ts
@@ -116,7 +116,7 @@ describe("ProtocolStatsService bridge volume", () => {
     const { query } = body as { query: string };
     expect(query).toContain("volumeStats");
     expect(query).toMatch(
-      new RegExp(`chainId\\s*:\\s*${ChainId.CITREA_MAINNET}\\b`),
+      new RegExp(`\\bchainId\\s*:\\s*${ChainId.CITREA_MAINNET}\\b`),
     );
     expect(JSON.stringify({ url, body })).not.toMatch(
       /juicedollar|bridgeVolumeStats/i,

--- a/src/services/__tests__/ProtocolStatsService.test.ts
+++ b/src/services/__tests__/ProtocolStatsService.test.ts
@@ -116,7 +116,7 @@ describe("ProtocolStatsService bridge volume", () => {
     const { query } = body as { query: string };
     expect(query).toContain("volumeStats");
     expect(query).toMatch(
-      new RegExp(`chainId:\\s*${ChainId.CITREA_MAINNET}\\b`),
+      new RegExp(`chainId\\s*:\\s*${ChainId.CITREA_MAINNET}\\b`),
     );
     expect(JSON.stringify({ url, body })).not.toMatch(
       /juicedollar|bridgeVolumeStats/i,

--- a/src/services/__tests__/ProtocolStatsService.test.ts
+++ b/src/services/__tests__/ProtocolStatsService.test.ts
@@ -1,0 +1,86 @@
+import { ChainId } from "@juiceswapxyz/sdk-core";
+import Logger from "bunyan";
+import axios from "axios";
+import { ethers } from "ethers";
+import { ProtocolStatsService } from "../ProtocolStatsService";
+import type { ExploreStatsService } from "../ExploreStatsService";
+
+jest.mock("axios");
+jest.mock("../PriceService", () => ({
+  PriceService: jest.fn().mockImplementation(() => ({
+    getBtcPriceUsd: jest.fn().mockResolvedValue(100000),
+  })),
+}));
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+function createMockLogger(): Logger {
+  const logger = {
+    child: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+  return logger as unknown as Logger;
+}
+
+function createService() {
+  const exploreStatsService = {
+    getExploreStats: jest
+      .fn()
+      .mockResolvedValue({ stats: { poolStatsV2: [], poolStatsV3: [] } }),
+  } as unknown as ExploreStatsService;
+
+  // Empty provider map → getBridgeTvl short-circuits to 0 without a multicall,
+  // so every axios.post seen here belongs to a bridge volume leg.
+  return new ProtocolStatsService(
+    new Map<ChainId, ethers.providers.StaticJsonRpcProvider>(),
+    createMockLogger(),
+    exploreStatsService,
+  );
+}
+
+describe("ProtocolStatsService bridge volume", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedAxios.post.mockResolvedValue({
+      data: {
+        data: {
+          volumeStats: {
+            items: [
+              {
+                tokenAddress: "0x0000000000000000000000000000000000000001",
+                timestamp: "1700000000",
+                volume: ethers.utils.parseUnits("7", 18).toString(),
+                type: "1h",
+              },
+            ],
+          },
+        },
+      },
+    });
+  });
+
+  it("queries only the LDS Ponder, never the JuiceDollar Ponder", async () => {
+    const service = createService();
+
+    await service.getProtocolStats(ChainId.CITREA_MAINNET);
+
+    expect(mockedAxios.post).toHaveBeenCalledTimes(1);
+    const [url, body] = mockedAxios.post.mock.calls[0];
+    expect(url).toContain("lightning.space");
+    expect(JSON.stringify({ url, body })).not.toMatch(
+      /juicedollar|bridgeVolumeStats/i,
+    );
+  });
+
+  it("reports bridge volume as the LDS leg alone", async () => {
+    const service = createService();
+
+    const stats = await service.getProtocolStats(ChainId.CITREA_MAINNET);
+
+    expect(stats.historicalProtocolVolume.Month.bridge[0].value).toBe(7);
+  });
+});


### PR DESCRIPTION
EN:
The JuiceDollar Ponder stack is being retired, so the JuiceDollar leg of the 24h bridge volume stat is removed from `ProtocolStatsService`. Bridge volume is now the LDS Ponder leg alone instead of carrying a permanently failing call that logs a warning on every stats request and contributes a silent `0`. The orphaned `JUICEDOLLAR_PONDER_URL` example env var and the README stats table are updated accordingly. Deployment environment variables live in a separate infrastructure repository and are handled outside this PR.

DE:
Der JuiceDollar-Ponder-Stack wird stillgelegt, deshalb entfällt das JuiceDollar-Bein der 24h-Bridge-Volume-Statistik in `ProtocolStatsService`. Das Bridge-Volumen besteht jetzt nur noch aus dem LDS-Bein, statt einen dauerhaft fehlschlagenden Call mitzuführen, der bei jedem Stats-Request eine Warnung loggt und still `0` beisteuert. Die verwaiste Beispiel-Env-Var `JUICEDOLLAR_PONDER_URL` und die README-Tabelle sind entsprechend angepasst. Die Env-Vars der Deploy-Umgebung liegen in einem separaten Infrastruktur-Repo und bleiben ausserhalb dieses PRs.

Closes #281

<details>
<summary>Details</summary>

### Change

`ProtocolStatsService.getStablecoinBridgeVolume()` queried the JuiceDollar Ponder
(`JUICEDOLLAR_PONDER_URL`, fallback `https://ponder.juicedollar.com`) for the 24h
`bridgeVolumeStats` buckets. The call is wrapped in try/catch and degrades to `0`, so there
is no crash risk — but once the JuiceDollar infrastructure is gone, every call fails
(timeout/DNS) and produces an endless warn log line for a leg that silently contributes `0`.

- `getStablecoinBridgeVolume()` removed, together with the now-vestigial `getBridgeVolume()`
  wrapper. `getBridgeStats()` calls `getLdsBridgeVolume(chainId)` directly, so bridge volume
  is the LDS leg alone rather than a dead `0` addend.
- Bridge TVL is untouched: it comes from `minted()` on the StablecoinBridge contracts via
  RPC multicall and never depended on the JuiceDollar Ponder.
- `.env.example`: `JUICEDOLLAR_PONDER_URL` removed (`LDS_PONDER_URL` stays).
- `README.md`: the 1D volume table now lists LDS Ponder as the only bridge source.
- Class and method JSDoc updated to match.

Related: #278 already removed the JuiceDollar leg from quote/swap routing; this is the
remaining stats-only leftover.

### Out of scope

The deployment environment variables for this service live in a separate infrastructure
repository and are part of a larger decommissioning runbook. They are intentionally not
touched here.

### Tests

New `src/services/__tests__/ProtocolStatsService.test.ts`. The `axios` mock branches on the
GraphQL query: a `bridgeVolumeStats` query (only reachable if the JuiceDollar leg came back)
is answered with 5 JUSD, the LDS `volumeStats` query with 7, and anything else throws.
`LDS_PONDER_URL` is pinned for the suite and restored afterwards.

- `queries only the LDS Ponder, never the JuiceDollar Ponder` — asserts exactly one
  `axios.post`, to the pinned LDS endpoint, carrying a `volumeStats` query for this chain and
  no JuiceDollar host or `bridgeVolumeStats` query.
- `reports bridge volume as the LDS leg alone` — bridge volume is 7, not 5 + 7.

Both fail against the pre-change service (two POSTs, and 12 instead of 7).

Local run of the CI gates on this branch:

```
npm run typecheck   # clean
npm run test:unit   # 11 passed, 1 skipped — 111 passed, 3 skipped
npm run build       # clean
npm run lint        # 0 errors (213 pre-existing warnings)
```

</details>
